### PR TITLE
GitHub auth as user

### DIFF
--- a/pkg/codebase/graphql/codebase.go
+++ b/pkg/codebase/graphql/codebase.go
@@ -443,8 +443,8 @@ func (r *codebaseResolver) LastUsedView(ctx context.Context) (resolvers.ViewReso
 	return (*r.root.viewResolver).InternalLastUsedViewByUser(ctx, r.c.ID, userID)
 }
 
-func (r *codebaseResolver) GitHubIntegration() (resolvers.CodebaseGitHubIntegrationResolver, error) {
-	resolver, err := (*r.root.codebaseGitHubIntegrationResolver).InternalCodebaseGitHubIntegration(graphql.ID(r.c.ID))
+func (r *codebaseResolver) GitHubIntegration(ctx context.Context) (resolvers.CodebaseGitHubIntegrationResolver, error) {
+	resolver, err := (*r.root.codebaseGitHubIntegrationResolver).InternalCodebaseGitHubIntegration(ctx, graphql.ID(r.c.ID))
 	switch {
 	case err == nil:
 		return resolver, nil

--- a/pkg/github/graphql/codebase_github_integration.go
+++ b/pkg/github/graphql/codebase_github_integration.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-
 	service_auth "mash/pkg/auth/service"
 	service_codebase "mash/pkg/codebase/service"
 	"mash/pkg/github"
@@ -89,8 +88,8 @@ func (r *codebaseGitHubIntegrationRootResolver) InternalGitHubRepositoryByID(id 
 	return resolver, nil
 }
 
-func (r *codebaseGitHubIntegrationRootResolver) InternalCodebaseGitHubIntegration(codebaseID graphql.ID) (resolvers.CodebaseGitHubIntegrationResolver, error) {
-	repo, err := r.resolveByCodebaseID(codebaseID)
+func (r *codebaseGitHubIntegrationRootResolver) InternalCodebaseGitHubIntegration(ctx context.Context, codebaseID graphql.ID) (resolvers.CodebaseGitHubIntegrationResolver, error) {
+	repo, err := r.resolveByCodebaseID(ctx, codebaseID)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}
@@ -127,7 +126,7 @@ func (r *codebaseGitHubIntegrationRootResolver) UpdateCodebaseGitHubIntegration(
 	return resolver, nil
 }
 
-func (r *codebaseGitHubIntegrationRootResolver) resolveByCodebaseID(codebaseID graphql.ID) (*codebaseGitHubIntegrationResolver, error) {
+func (r *codebaseGitHubIntegrationRootResolver) resolveByCodebaseID(ctx context.Context, codebaseID graphql.ID) (*codebaseGitHubIntegrationResolver, error) {
 	repo, err := r.gitHubRepositoryRepo.GetByCodebaseID(string(codebaseID))
 	if err != nil {
 		return nil, err

--- a/pkg/github/service/clone.go
+++ b/pkg/github/service/clone.go
@@ -114,7 +114,7 @@ func (svc *Service) Clone(
 	}
 
 	// Grant access for other users (the sender already has access)
-	if err := svc.GrantCollaboratorsAccess(ctx, codebaseID); err != nil {
+	if err := svc.GrantCollaboratorsAccess(ctx, codebaseID, strOrNilIfEmpty(senderUserID)); err != nil {
 		return fmt.Errorf("failed to GrantCollaboratorsAccess: %w", err)
 	}
 
@@ -124,6 +124,13 @@ func (svc *Service) Clone(
 	logger.Info("successfully cloned repository, and marked it as ready!")
 
 	return nil
+}
+
+func strOrNilIfEmpty(str string) *string {
+	if str == "" {
+		return nil
+	}
+	return &str
 }
 
 func (svc *Service) CloneMissingRepositories(ctx context.Context, userID string) error {

--- a/pkg/graphql/resolvers/codebase.go
+++ b/pkg/graphql/resolvers/codebase.go
@@ -52,7 +52,7 @@ type CodebaseResolver interface {
 	Members(context.Context) ([]AuthorResolver, error)
 	Views(ctx context.Context, args CodebaseViewsArgs) ([]ViewResolver, error)
 	LastUsedView(ctx context.Context) (ViewResolver, error)
-	GitHubIntegration() (CodebaseGitHubIntegrationResolver, error)
+	GitHubIntegration(context.Context) (CodebaseGitHubIntegrationResolver, error)
 	IsReady() bool
 	ACL(context.Context) (ACLResolver, error)
 	Changes(ctx context.Context, args *CodebaseChangesArgs) ([]ChangeResolver, error)

--- a/pkg/graphql/resolvers/codebase_github_integration.go
+++ b/pkg/graphql/resolvers/codebase_github_integration.go
@@ -8,7 +8,7 @@ import (
 
 type CodebaseGitHubIntegrationRootResolver interface {
 	// Internal APIs
-	InternalCodebaseGitHubIntegration(codebaseID graphql.ID) (CodebaseGitHubIntegrationResolver, error)
+	InternalCodebaseGitHubIntegration(ctx context.Context, codebaseID graphql.ID) (CodebaseGitHubIntegrationResolver, error)
 	InternalGitHubRepositoryByID(id string) (CodebaseGitHubIntegrationResolver, error)
 
 	// Mutations


### PR DESCRIPTION
<p>pkg/github: prefer authenticating as a user over the app</p><p>The app does not have access to list all collaborators, and only sees the collaborators that have made their membership of the organisation public.</p><p>Authenticating as a user (someone who already is a collaborator) allows us to see the rest of the collaborators.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-public-zyTDsnY/513c77ff-ca55-4f66-82f8-4a5fdcc15324) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
