### PR TITLE
Allow Rebasing

### DIFF
--- a/vcs/executor/executor.go
+++ b/vcs/executor/executor.go
@@ -144,6 +144,11 @@ func (e *executor) Git(fn GitFunc) Executor {
 	return e
 }
 
+func (e *executor) gitFirst(fn GitFunc) Executor {
+	e.funs = append([]*executeFunc{{repoFun: fn}}, e.funs...)
+	return e
+}
+
 func (e *executor) AllowRebasingState() Executor {
 	e.allowRebasing = true
 	return e
@@ -198,7 +203,7 @@ func (e *executor) exec(codebaseID string, viewID *string, actionName string) (e
 	defer logger.Info("git executor completed", zap.Duration("duration", time.Since(t0)))
 
 	if !e.allowRebasing {
-		e.Git(func(repo vcs.Repo) error {
+		e.gitFirst(func(repo vcs.Repo) error {
 			if repo.IsRebasing() {
 				return ErrIsRebasing
 			}

--- a/vcs/executor/executor_test.go
+++ b/vcs/executor/executor_test.go
@@ -1,0 +1,61 @@
+package executor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"mash/vcs"
+	"mash/vcs/provider"
+	"mash/vcs/testutil"
+)
+
+func TestExecutor_AllowRebasingState(t *testing.T) {
+	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t))
+
+	// create repo
+	err := exec.New().AllowRebasingState().Schedule(func(repoProvider provider.RepoProvider) error {
+		path := repoProvider.ViewPath("cb", "vw")
+		repo, err := vcs.CreateNonBareRepoWithRootCommit(path, "testtrunk")
+		if err != nil {
+			return fmt.Errorf("failed to create trunk: %w", err)
+		}
+
+		assert.NoError(t, repo.CreateNewBranchOnHEAD("b1"))
+		assert.NoError(t, repo.CreateNewBranchOnHEAD("b2"))
+
+		assert.NoError(t, repo.CheckoutBranchWithForce("b1"))
+		assert.NoError(t, ioutil.WriteFile(filepath.Join(path, "a.txt"), []byte("foo"), 0o644))
+		cb1, err := repo.AddAndCommit("hey-b1")
+		assert.NoError(t, err)
+
+		assert.NoError(t, repo.CheckoutBranchWithForce("b2"))
+		assert.NoError(t, ioutil.WriteFile(filepath.Join(path, "a.txt"), []byte("bar"), 0o644))
+		cb2, err := repo.AddAndCommit("hey-b2")
+		assert.NoError(t, err)
+
+		rb, _, err := repo.InitRebaseRaw(cb1, cb2)
+		assert.NoError(t, err)
+		assert.NotNil(t, rb)
+		assert.True(t, repo.IsRebasing())
+		return nil
+	}).ExecView("cb", "vw", "createView")
+	assert.NoError(t, err)
+
+	// the view is not conflicting, try to open again without conflicts allowed
+	err = exec.New().Read(func(reader vcs.RepoReader) error {
+		return nil
+	}).ExecView("cb", "vw", "tryToOpen")
+	assert.ErrorIs(t, err, ErrIsRebasing)
+
+	// can open if rebasing is allowed
+	err = exec.New().AllowRebasingState().Read(func(reader vcs.RepoReader) error {
+		assert.True(t, reader.IsRebasing())
+		return nil
+	}).ExecView("cb", "vw", "tryToOpenWithAllowed")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<p>vcs/executor: correctly prevent access if a view is rebasing</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/9601f15a-e315-474d-98a4-aa790cdf523f) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
