### PR TITLE
web: load features and user in separate queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ __generated__/
 /app/dist/
 /app/sturdy-v0.7.6-beta3-windows-amd64.zip
 /web/src/components/emoji/emojis.json
+/backend/mash


### PR DESCRIPTION
<p>web: load features and user in separate queries</p><p>This allows us to get features from the server even if the request isn’t authenticated.</p><p>An ideal fix would be to make the user optional in the GraphQL schema, but that’s a bigger fix that takes some work to get right.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/3a27c759-de29-4abd-abcd-e55a56e8893b) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
