### PR TITLE
GitHub Pushes

### DIFF
--- a/api/pkg/github/enterprise/routes/push/push.go
+++ b/api/pkg/github/enterprise/routes/push/push.go
@@ -268,5 +268,11 @@ func HandlePushEvent(
 			}
 		}
 	}
+
+	// Allow all workspaces to be rebased/synced on the latest head
+	if err := workspaceWriter.UnsetUpToDateWithTrunkForAllInCodebase(repo.CodebaseID); err != nil {
+		return fmt.Errorf("failed to unset up to date with trunk for all in codebase: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
<p>pkg/github: always unset workspace caches after push</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/23bb2abc-f62a-474e-bebf-1c186c0902ae) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
