### PR TITLE
Organization Access

### DIFF
--- a/api/pkg/auth/service/service_test.go
+++ b/api/pkg/auth/service/service_test.go
@@ -9,6 +9,8 @@ import (
 	"getsturdy.com/api/pkg/codebase"
 	service_codebase "getsturdy.com/api/pkg/codebase/service"
 	"getsturdy.com/api/pkg/internal/inmemory"
+	"getsturdy.com/api/pkg/organization"
+	service_organization "getsturdy.com/api/pkg/organization/service"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -108,6 +110,8 @@ func TestCanRead_codebase(t *testing.T) {
 		isMember         bool
 		codebaseIsPublic bool
 
+		isMemberOfOrganization bool
+
 		expected bool
 	}{
 		{
@@ -140,23 +144,40 @@ func TestCanRead_codebase(t *testing.T) {
 			isAuthenticated: true, isMember: true, codebaseIsPublic: true,
 			expected: true,
 		},
+
+		{
+			name:            "user-can-read-private-codebase-member-of-organization",
+			isAuthenticated: true, isMember: false, isMemberOfOrganization: true, codebaseIsPublic: false,
+			expected: true,
+		},
 	}
 
 	codebaseRepo := inmemory.NewInMemoryCodebaseRepo()
 	codebaseUserRepo := inmemory.NewInMemoryCodebaseUserRepo()
 	codebaseService := service_codebase.New(codebaseRepo, codebaseUserRepo, nil, nil, nil, nil, nil)
 
+	organizationRepo := inmemory.NewInMemoryOrganizationRepo()
+	organizationMemberRepo := inmemory.NewInMemoryOrganizationMemberRepository()
+	organizationService := service_organization.New(organizationRepo, organizationMemberRepo)
+
 	authService := service_auth.New(
 		codebaseService,
 		nil,
 		nil,
 		nil,
-		nil,
+		organizationService,
 	)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			orgID := uuid.NewString()
+
 			cb := codebase.Codebase{ID: uuid.NewString(), IsPublic: tc.codebaseIsPublic}
+
+			if tc.isMemberOfOrganization {
+				cb.OrganizationID = &orgID
+			}
+
 			assert.NoError(t, codebaseRepo.Create(cb))
 
 			userID := uuid.NewString()
@@ -164,6 +185,13 @@ func TestCanRead_codebase(t *testing.T) {
 			if tc.isMember {
 				cbu := codebase.CodebaseUser{ID: uuid.NewString(), CodebaseID: cb.ID, UserID: userID}
 				assert.NoError(t, codebaseUserRepo.Create(cbu))
+			}
+
+			if tc.isMemberOfOrganization {
+				org := organization.Organization{ID: orgID}
+				assert.NoError(t, organizationRepo.Create(context.Background(), org))
+				orgmember := organization.Member{ID: uuid.NewString(), OrganizationID: org.ID, UserID: userID}
+				assert.NoError(t, organizationMemberRepo.Create(context.Background(), orgmember))
 			}
 
 			ctx := context.Background()
@@ -179,6 +207,110 @@ func TestCanRead_codebase(t *testing.T) {
 				assert.NoError(t, hasAccessErr)
 			} else {
 				assert.Error(t, hasAccessErr)
+			}
+		})
+	}
+}
+
+func TestCanReadWrite_organization(t *testing.T) {
+	cases := []struct {
+		name string
+
+		isAuthenticated    bool
+		isMember           bool
+		isMemberOfCodebase bool
+
+		expectedCanRead  bool
+		expectedCanWrite bool
+	}{
+		{
+			name:            "member-can-access",
+			isAuthenticated: true, isMember: true, isMemberOfCodebase: false,
+
+			expectedCanRead:  true,
+			expectedCanWrite: true,
+		},
+		{
+			name:            "non-member-can-not-access",
+			isAuthenticated: true, isMember: false, isMemberOfCodebase: false,
+
+			expectedCanRead:  false,
+			expectedCanWrite: false,
+		},
+		{
+			name:            "member-can-access-if-member-of-codebase",
+			isAuthenticated: true, isMember: true, isMemberOfCodebase: true,
+
+			expectedCanRead:  true,
+			expectedCanWrite: true,
+		},
+		{
+			name:            "non-member-can-read-only-access-if-member-of-codebase",
+			isAuthenticated: true, isMember: false, isMemberOfCodebase: true,
+
+			expectedCanRead:  true,
+			expectedCanWrite: false,
+		},
+	}
+
+	codebaseRepo := inmemory.NewInMemoryCodebaseRepo()
+	codebaseUserRepo := inmemory.NewInMemoryCodebaseUserRepo()
+	codebaseService := service_codebase.New(codebaseRepo, codebaseUserRepo, nil, nil, nil, nil, nil)
+
+	organizationRepo := inmemory.NewInMemoryOrganizationRepo()
+	organizationMemberRepo := inmemory.NewInMemoryOrganizationMemberRepository()
+	organizationService := service_organization.New(organizationRepo, organizationMemberRepo)
+
+	authService := service_auth.New(
+		codebaseService,
+		nil,
+		nil,
+		nil,
+		organizationService,
+	)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bgCtx := context.Background()
+
+			org := organization.Organization{ID: uuid.NewString()}
+			assert.NoError(t, organizationRepo.Create(bgCtx, org))
+
+			userID := uuid.NewString()
+
+			if tc.isMember {
+				orgmember := organization.Member{ID: uuid.NewString(), OrganizationID: org.ID, UserID: userID}
+				assert.NoError(t, organizationMemberRepo.Create(bgCtx, orgmember))
+			}
+
+			if tc.isMemberOfCodebase {
+				cb := codebase.Codebase{ID: uuid.NewString(), OrganizationID: &org.ID}
+				assert.NoError(t, codebaseRepo.Create(cb))
+
+				cbu := codebase.CodebaseUser{ID: uuid.NewString(), CodebaseID: cb.ID, UserID: userID}
+				assert.NoError(t, codebaseUserRepo.Create(cbu))
+			}
+
+			ctx := context.Background()
+
+			if tc.isAuthenticated {
+				ctx = auth.NewContext(ctx, &auth.Subject{ID: userID, Type: auth.SubjectUser})
+			} else {
+				ctx = auth.NewContext(ctx, &auth.Subject{Type: auth.SubjectAnonymous})
+			}
+
+			canReadAccessErr := authService.CanRead(ctx, org)
+			if tc.expectedCanRead {
+				assert.NoError(t, canReadAccessErr)
+			} else {
+				assert.Error(t, canReadAccessErr)
+			}
+
+			canWriteAccessErr := authService.CanWrite(ctx, org)
+			if tc.expectedCanWrite {
+				assert.NoError(t, canWriteAccessErr)
+			} else {
+				assert.Error(t, canWriteAccessErr)
 			}
 		})
 	}

--- a/api/pkg/internal/inmemory/inmemory_codebase_user_repository.go
+++ b/api/pkg/internal/inmemory/inmemory_codebase_user_repository.go
@@ -2,6 +2,7 @@ package inmemory
 
 import (
 	"database/sql"
+
 	"getsturdy.com/api/pkg/codebase"
 	db_codebase "getsturdy.com/api/pkg/codebase/db"
 )
@@ -18,9 +19,17 @@ func (r *inMemoryCodebaseUserRepository) Create(entity codebase.CodebaseUser) er
 	r.users = append(r.users, entity)
 	return nil
 }
+
 func (r *inMemoryCodebaseUserRepository) GetByUser(userID string) ([]*codebase.CodebaseUser, error) {
-	panic("not implemented")
+	var res []*codebase.CodebaseUser
+	for _, u := range r.users {
+		if u.UserID == userID {
+			res = append(res, &u)
+		}
+	}
+	return res, nil
 }
+
 func (r *inMemoryCodebaseUserRepository) GetByCodebase(codebaseID string) ([]*codebase.CodebaseUser, error) {
 	var res []*codebase.CodebaseUser
 	for _, u := range r.users {
@@ -30,6 +39,7 @@ func (r *inMemoryCodebaseUserRepository) GetByCodebase(codebaseID string) ([]*co
 	}
 	return res, nil
 }
+
 func (r *inMemoryCodebaseUserRepository) GetByUserAndCodebase(userID, codebaseID string) (*codebase.CodebaseUser, error) {
 	for _, u := range r.users {
 		if u.UserID == userID && u.CodebaseID == codebaseID {

--- a/api/pkg/internal/inmemory/inmemory_organization_member_repository.go
+++ b/api/pkg/internal/inmemory/inmemory_organization_member_repository.go
@@ -1,0 +1,60 @@
+package inmemory
+
+import (
+	"context"
+	"database/sql"
+
+	"getsturdy.com/api/pkg/organization"
+	db_organization "getsturdy.com/api/pkg/organization/db"
+)
+
+type inMemoryOrganizationMemberRepository struct {
+	users []organization.Member
+}
+
+func NewInMemoryOrganizationMemberRepository() db_organization.MemberRepository {
+	return &inMemoryOrganizationMemberRepository{users: make([]organization.Member, 0)}
+}
+
+func (r *inMemoryOrganizationMemberRepository) GetByUserIDAndOrganizationID(ctx context.Context, userID, organizationID string) (*organization.Member, error) {
+	for _, u := range r.users {
+		if u.UserID == userID && u.OrganizationID == organizationID {
+			return &u, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *inMemoryOrganizationMemberRepository) ListByOrganizationID(ctx context.Context, id string) ([]*organization.Member, error) {
+	var res []*organization.Member
+	for _, u := range r.users {
+		if u.OrganizationID == id {
+			res = append(res, &u)
+		}
+	}
+	return res, nil
+}
+
+func (r *inMemoryOrganizationMemberRepository) ListByUserID(ctx context.Context, id string) ([]*organization.Member, error) {
+	var res []*organization.Member
+	for _, u := range r.users {
+		if u.UserID == id {
+			res = append(res, &u)
+		}
+	}
+	return res, nil
+}
+
+func (r *inMemoryOrganizationMemberRepository) Create(ctx context.Context, org organization.Member) error {
+	r.users = append(r.users, org)
+	return nil
+}
+
+func (r *inMemoryOrganizationMemberRepository) Update(ctx context.Context, org *organization.Member) error {
+	for k, v := range r.users {
+		if v.ID == org.ID {
+			r.users[k] = *org
+		}
+	}
+	return nil
+}

--- a/api/pkg/internal/inmemory/inmemory_organization_repository.go
+++ b/api/pkg/internal/inmemory/inmemory_organization_repository.go
@@ -1,0 +1,56 @@
+package inmemory
+
+import (
+	"context"
+	"database/sql"
+
+	"getsturdy.com/api/pkg/organization"
+	db_organization "getsturdy.com/api/pkg/organization/db"
+)
+
+type inMemoryOrganizationRepository struct {
+	orgs []organization.Organization
+}
+
+func NewInMemoryOrganizationRepo() db_organization.Repository {
+	return &inMemoryOrganizationRepository{orgs: make([]organization.Organization, 0)}
+}
+
+func (r *inMemoryOrganizationRepository) Get(ctx context.Context, id string) (*organization.Organization, error) {
+	for _, org := range r.orgs {
+		if org.ID == id {
+			return &org, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *inMemoryOrganizationRepository) GetByShortID(ctx context.Context, shortID organization.ShortOrganizationID) (*organization.Organization, error) {
+	for _, org := range r.orgs {
+		if org.ShortID == shortID {
+			return &org, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *inMemoryOrganizationRepository) GetFirst(ctx context.Context) (*organization.Organization, error) {
+	if len(r.orgs) > 0 {
+		return &r.orgs[0], nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *inMemoryOrganizationRepository) Create(ctx context.Context, org organization.Organization) error {
+	r.orgs = append(r.orgs, org)
+	return nil
+}
+
+func (r *inMemoryOrganizationRepository) Update(ctx context.Context, org *organization.Organization) error {
+	for k, v := range r.orgs {
+		if v.ID == org.ID {
+			r.orgs[k] = *org
+		}
+	}
+	return nil
+}

--- a/api/pkg/organization/service/service.go
+++ b/api/pkg/organization/service/service.go
@@ -55,6 +55,14 @@ func (svc *Service) Members(ctx context.Context, organizationID string) ([]*orga
 	return members, nil
 }
 
+func (svc *Service) GetMember(ctx context.Context, organizationID, userID string) (*organization.Member, error) {
+	member, err := svc.organizationMemberRepository.GetByUserIDAndOrganizationID(ctx, userID, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	return member, nil
+}
+
 func (svc *Service) Create(ctx context.Context, name string) (*organization.Organization, error) {
 	userID, err := auth.UserID(ctx)
 	if err != nil {


### PR DESCRIPTION
<p>pkg/auth: allow CanRead on an organization if the subject is a member of any of the organizations codebases</p><ul><li><p>Include all organization members as codebase members (to deal with lack of CanI on the web frontend)</p></li></ul>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/fe2710c2-d00d-4677-b49c-d362a6907395) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
