### PR TITLE
Pricing Documentation

### DIFF
--- a/web/src/organisms/docs/DocsSidebar.vue
+++ b/web/src/organisms/docs/DocsSidebar.vue
@@ -51,13 +51,11 @@ const groups = [
       { route: 'v2DocsHowToSwitchBetweenTasks', title: 'Switch between tasks' },
     ],
   },
-  //  { name: 'index', title: 'Self-host' },
-  //  { name: 'index', title: 'Cloud' },
-  //  { name: 'index', title: 'User Guides' },
-  //  { name: 'index', title: 'API' },
-  //  { name: 'index', title: 'API' },
-  //  { name: 'index', title: 'API' },
-  //  { name: 'index', title: 'API' },
+
+  {
+    name: 'Enterprise',
+    links: [{ route: 'v2DocsPricing', title: 'Pricing' }],
+  },
 ]
 
 export default defineComponent({

--- a/web/src/pages/docs/Pricing.vue
+++ b/web/src/pages/docs/Pricing.vue
@@ -1,0 +1,60 @@
+<template>
+  <PublicLeftSidebar>
+    <template #sidebar>
+      <DocsSidebar />
+    </template>
+    <template #default>
+      <div class="prose p-4 max-w-[800px]">
+        <h1 id="pricing">Pricing</h1>
+        <p>Sturdy comes in a few variants, with different pricing.</p>
+
+        <h2 id="open-source-sturdy">Self-hosted Sturdy Open Source</h2>
+        <p>Self-hosted, and free forever.</p>
+
+        <h2 id="sturdy-cloud">Sturdy Cloud</h2>
+        <p>Sturdy-the-product, hosted by Sturdy-the-company.</p>
+        <ul>
+          <li>20 users per organization is free</li>
+          <li>$10 / user / month (billed monthly)</li>
+        </ul>
+
+        <h2 id="self-hosted-sturdy-enterprise">Self-hosted Sturdy Enterprise</h2>
+        <ul>
+          <li>Up to 20 users for free</li>
+          <li>$10 / user / month (billed annually, minimum 20 seats)</li>
+          <li>
+            Extra used seats (outside of seats included in the license) are pro-rated (billed
+            monthly)
+          </li>
+          <li>
+            Dedicated Slack-support, hosting support, and remote debugging and configuration by
+            Sturdy engineers is <em>included for paying customers</em>.
+          </li>
+          <li>Community-support is available for all users</li>
+        </ul>
+      </div>
+    </template>
+  </PublicLeftSidebar>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import PublicLeftSidebar from '../../layouts/PublicLeftSidebar.vue'
+import { useHead } from '@vueuse/head'
+import DocsSidebar from '../../organisms/docs/DocsSidebar.vue'
+
+export default defineComponent({
+  components: { DocsSidebar, PublicLeftSidebar },
+  setup() {
+    // TODO: Remove when we're launching!
+    useHead({
+      meta: [
+        {
+          name: 'robots',
+          content: 'noindex',
+        },
+      ],
+    })
+  },
+})
+</script>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -589,6 +589,12 @@ export const routes: RouteRecordRaw[] = [
     meta: { nonApp: true, selfContainedLayout: true, neverElectron: true },
   },
   {
+    path: '/v2/docs/pricing',
+    component: () => import('./pages/docs/Pricing.vue'),
+    name: 'v2DocsPricing',
+    meta: { nonApp: true, selfContainedLayout: true, neverElectron: true },
+  },
+  {
     path: '/join/:code',
     component: () => import('./components/join/Join.vue'),
     name: 'join',


### PR DESCRIPTION
<p>web/docs: add a pricing documentation page (not the same as a flashy /pricing page)</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/cb795fb9-2b41-48c7-b02d-9f53e2dee277) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
