### PR TITLE
pkg/codebases: ignore not found errors in listing

### DIFF
--- a/api/pkg/codebase/service/service.go
+++ b/api/pkg/codebase/service/service.go
@@ -145,10 +145,13 @@ func (svc *Service) orgsByUser(ctx context.Context, userID string) (map[string]s
 
 	for _, cu := range codebaseUsers {
 		cb, err := svc.repo.Get(cu.CodebaseID)
-		if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// ignore
+			continue
+		case err != nil:
 			return nil, fmt.Errorf("could not get codebase: %w", err)
-		}
-		if cb.OrganizationID != nil {
+		case cb.OrganizationID != nil:
 			orgIDs[*cb.OrganizationID] = struct{}{}
 		}
 	}


### PR DESCRIPTION
<p>api/pkg/codebase: ignore codebase not found errors when listing codebases</p><p>This was causing errors in auth for organizations.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/187d6831-4448-4e4e-b766-ebe9c0ed1d17) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
