### PR TITLE
Organizations: remove automatic GitHub clone

### DIFF
--- a/api/pkg/github/enterprise/routes/installation/webhook_installation_repositories.go
+++ b/api/pkg/github/enterprise/routes/installation/webhook_installation_repositories.go
@@ -148,9 +148,5 @@ func handleInstalledRepository(
 		return nil
 	}
 
-	if _, err := gitHubService.CreateNonReadyCodebaseAndClone(ctx, ghRepo, installationID, sender, nil, nil); err != nil {
-		return fmt.Errorf("failed to create non-ready codebase: %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
<p>api/pkg/github: disable automatic GitHub cloning</p><p>This will now be done manually from the organizations settings</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/0dfa4de7-0e95-47bb-9fa1-4f95b0cdae2b) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
