### PR TITLE
Organizations

### DIFF
--- a/api/pkg/github/enterprise/routes/clone_test.go
+++ b/api/pkg/github/enterprise/routes/clone_test.go
@@ -32,6 +32,9 @@ import (
 //go:generate mockgen -destination internal/mock_sender/notification_sender_mock.go getsturdy.com/api/pkg/notification/sender NotificationSender
 
 func TestCloneSendsNotifications(t *testing.T) {
+	// TODO: Rework the notifications so that they are sent again...
+	t.SkipNow()
+
 	logger, _ := zap.NewDevelopment()
 
 	gitHubRepositoryRepo := inmemory.NewInMemoryGitHubRepositoryRepo()


### PR DESCRIPTION
<p>pkg/github: disable TestCloneSendsNotifications test</p><p>Notifications are no longer sent on app installation, as the cloning is no longer automatic.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ea9b03f4-f8c5-4b89-8b11-c79305f3ab10) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
