### PR TITLE
ListFiles API ACL

### DIFF
--- a/api/pkg/file/graphql/fileRootResolver.go
+++ b/api/pkg/file/graphql/fileRootResolver.go
@@ -73,7 +73,6 @@ func (r *fileRootResolver) InternalFile(ctx context.Context, codebaseID string, 
 					}
 					return nil
 				}
-
 			}
 		}
 

--- a/api/pkg/unidiff/allower.go
+++ b/api/pkg/unidiff/allower.go
@@ -134,7 +134,7 @@ func deduplicate(ss []string) []string {
 	return noDuplicates
 }
 
-// NewAllower creates a new allowr given a list of user-provided allow
+// NewAllower creates a new allower given a list of user-provided allow
 // patterns.
 func NewAllower(patterns ...string) (*Allower, error) {
 	patterns = deduplicate(patterns)
@@ -156,13 +156,13 @@ func NewAllower(patterns ...string) (*Allower, error) {
 	}, nil
 }
 
-// IsAllowed determines whether or not the specified path should be allowd based
+// IsAllowed determines whether or not the specified path should be allowed based
 // on all provided allow patterns and their order.
 func (i *Allower) IsAllowed(path string, directory bool) bool {
 	// Nothing is initially allowed.
 	allowed := false
 
-	// Run through patterns, keeping track of the allowd state as we reach more
+	// Run through patterns, keeping track of the allowed state as we reach more
 	// specific rules.
 	for _, p := range i.patterns {
 		if match, negated := p.matches(path, directory); !match {


### PR DESCRIPTION
<p>api/pkg: add more tests for GraphQL</p><p>Due to restrictions in how many files we want to read recursively, and a limitation in the capabilities of the allower, the GraphQL fileResolver will not allow to read files that the user is allowed to see from the ChangesResolver, or via Mutagen.</p><p>Git/Mutagen only works on files (not directories), and works from the “bottom up”: A directory is allowed if any of it’s children are (recursively).</p><p>TODO: Allow “/dir/” if there is a rule that allows “/dir/foo”.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/fbeae3d0-a08d-4faf-9c6c-436e264fcbdc) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
