### PR TITLE
RWGitRepo

### DIFF
--- a/api/pkg/change/graphql/resolver.go
+++ b/api/pkg/change/graphql/resolver.go
@@ -5,8 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	vcsvcs "getsturdy.com/api/vcs"
 	"sync"
+
+	vcsvcs "getsturdy.com/api/vcs"
 
 	service_auth "getsturdy.com/api/pkg/auth/service"
 	"getsturdy.com/api/pkg/change"
@@ -201,7 +202,7 @@ func (r *ChangeResolver) Diffs(ctx context.Context) ([]resolvers.FileDiffResolve
 	}
 
 	var diffs []string
-	err := r.root.executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+	err := r.root.executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 		var err error
 		diffs, err = vcs.GetDiffs(repo, r.changeOnTrunk.CommitID)
 		if err != nil {

--- a/api/pkg/ci/service/service.go
+++ b/api/pkg/ci/service/service.go
@@ -90,7 +90,7 @@ var downloadBash string
 
 func (svc *Service) loadSeedFiles(commit *change.ChangeCommit, seedFiles []string) (map[string][]byte, error) {
 	seedFilesContents := make(map[string][]byte)
-	if err := svc.executorProvider.New().Git(func(repo vcs.Repo) error {
+	if err := svc.executorProvider.New().GitRead(func(repo vcs.RepoGitReader) error {
 		for _, sf := range seedFiles {
 			contents, err := repo.FileContentsAtCommit(commit.CommitID, sf)
 			switch {

--- a/api/pkg/codebase/graphql/codebase.go
+++ b/api/pkg/codebase/graphql/codebase.go
@@ -268,7 +268,7 @@ func (r *CodebaseRootResolver) UpdateCodebase(ctx context.Context, args resolver
 	if !ok {
 		return nil, gqlerrors.Error(fmt.Errorf("could not get auth"))
 	}
-	
+
 	if args.Input.Name != nil && len(*args.Input.Name) > 0 {
 		cb.Name = *args.Input.Name
 	}
@@ -396,7 +396,7 @@ func (r *CodebaseResolver) calculateLastUpdatedAt() *int32 {
 	var largestTime int32
 
 	var gitTime time.Time
-	if err := r.root.executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+	if err := r.root.executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 		changes, err := vcs.ListChanges(repo, 1)
 		if err != nil || len(changes) == 0 {
 			return fmt.Errorf("failed to list changes: %w", err)
@@ -581,7 +581,7 @@ func (r *CodebaseResolver) Changes(ctx context.Context, args *resolvers.Codebase
 	// This is not ideal. If we could make sure that the database is already is up to date with the Git state,
 	// we would not have to read from disk here.
 	var log []*vcsvcs.LogEntry
-	if err := r.root.executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+	if err := r.root.executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 		var err error
 		log, err = vcs.ListChanges(repo, limit)
 		if err != nil {

--- a/api/pkg/codebase/routes/get.go
+++ b/api/pkg/codebase/routes/get.go
@@ -30,7 +30,7 @@ func Get(
 ) gin.HandlerFunc {
 	lastUpdatedAt := func(codebaseID string) time.Time {
 		var gitTime time.Time
-		if err := executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+		if err := executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 			changes, err := vcs.ListChanges(repo, 1)
 			if err != nil || len(changes) == 0 {
 				return fmt.Errorf("failed to list changes: %w", err)

--- a/api/pkg/codebase/vcs/vcs.go
+++ b/api/pkg/codebase/vcs/vcs.go
@@ -31,7 +31,7 @@ func Import(trunkProvider provider.TrunkProvider, codebaseID, gitURL string) err
 }
 
 // If no limit is set, a default of 100 is used
-func ListChanges(repo vcs.Repo, limit int) ([]*vcs.LogEntry, error) {
+func ListChanges(repo vcs.RepoGitReader, limit int) ([]*vcs.LogEntry, error) {
 	if limit < 1 {
 		limit = 100
 	}

--- a/api/pkg/comments/live/fs.go
+++ b/api/pkg/comments/live/fs.go
@@ -59,7 +59,7 @@ func snapshotFS(
 
 func (snapshotsFS *SnapshotsFS) Open(path string) (fs.File, error) {
 	var file fs.File
-	return file, snapshotsFS.executorProvider.New().Git(func(repo vcs.Repo) error {
+	return file, snapshotsFS.executorProvider.New().GitRead(func(repo vcs.RepoGitReader) error {
 		if snapshotsFS.newLines {
 			var err error
 			file, err = fileFromCommit(repo, snapshotsFS.snapshot.CommitID, path)
@@ -114,7 +114,7 @@ func (viewFS *ViewFS) Open(path string) (fs.File, error) {
 	}
 
 	var file fs.File
-	return file, viewFS.executorProvider.New().Git(func(repo vcs.Repo) error {
+	return file, viewFS.executorProvider.New().GitRead(func(repo vcs.RepoGitReader) error {
 		headCommit, err := repo.HeadCommit()
 		if err != nil {
 			return fmt.Errorf("failed to get head commit: %w", err)
@@ -126,7 +126,7 @@ func (viewFS *ViewFS) Open(path string) (fs.File, error) {
 	}).ExecView(viewFS.codebaseID, viewFS.viewID, fmt.Sprintf("open %s", path))
 }
 
-func fileFromCommit(repo vcs.Repo, commitSHA string, path string) (fs.File, error) {
+func fileFromCommit(repo vcs.RepoGitReader, commitSHA string, path string) (fs.File, error) {
 	blob, err := repo.FileBlobAtCommit(commitSHA, path)
 	switch {
 	case err == nil:

--- a/api/pkg/file/graphql/fileRootResolver.go
+++ b/api/pkg/file/graphql/fileRootResolver.go
@@ -37,7 +37,7 @@ func (r *fileRootResolver) InternalFile(ctx context.Context, codebaseID string, 
 		return nil, gqlerrors.Error(err)
 	}
 
-	err = r.executorProvider.New().Git(func(repo vcs.Repo) error {
+	err = r.executorProvider.New().GitRead(func(repo vcs.RepoGitReader) error {
 		headCommit, err := repo.HeadCommit()
 		if err != nil {
 			return multierr.Combine(gqlerrors.ErrNotFound, err)

--- a/api/pkg/gc/worker/worker.go
+++ b/api/pkg/gc/worker/worker.go
@@ -248,7 +248,7 @@ func gcSnapshot(
 	logger.Info("deleting snapshot")
 
 	// Delete branch on trunk
-	if err := executorProvider.New().Git(func(trunkRepo vcs.Repo) error {
+	if err := executorProvider.New().GitWrite(func(trunkRepo vcs.RepoGitWriter) error {
 		if err := trunkRepo.DeleteBranch(snapshotBranchName); err != nil {
 			return fmt.Errorf("failed to delete snapshot branch on trunk: %w", err)
 		}
@@ -266,7 +266,7 @@ func gcSnapshot(
 	if snapshot.ViewID != "" {
 		if err := executorProvider.New().
 			AllowRebasingState(). // allowed to enable branch deletion even if the view is currently rebasing
-			Git(func(viewGitRepo vcs.Repo) error {
+			GitWrite(func(viewGitRepo vcs.RepoGitWriter) error {
 				if err := viewGitRepo.DeleteBranch(snapshotBranchName); err != nil {
 					return fmt.Errorf("failed to delete snapshot branch from view: %w", err)
 				}
@@ -333,7 +333,7 @@ func work(
 		// do not fail
 	}
 
-	if err := executorProvider.New().Git(func(trunkRepo vcs.Repo) error {
+	if err := executorProvider.New().GitWrite(func(trunkRepo vcs.RepoGitWriter) error {
 		if err := trunkRepo.GitReflogExpire(); err != nil {
 			logger.Error("failed to run git-reflog expire on trunk", zap.Error(err))
 			// don't exit
@@ -361,7 +361,7 @@ func work(
 	for _, view := range views {
 		logger := logger.With(zap.String("view_id", view.ID))
 
-		if err := executorProvider.New().Git(func(viewGitRepo vcs.Repo) error {
+		if err := executorProvider.New().GitWrite(func(viewGitRepo vcs.RepoGitWriter) error {
 			if err := viewGitRepo.GitReflogExpire(); err != nil {
 				logger.Error("failed to run git-reflog expire on trunk", zap.Error(err))
 				// don't exit

--- a/api/pkg/github/enterprise/routes/push/push.go
+++ b/api/pkg/github/enterprise/routes/push/push.go
@@ -98,8 +98,8 @@ func HandlePushEvent(
 
 	var maybeImportedChanges []*vcs.LogEntry
 	if err := executorProvider.New().
-		Git(vcs_github.FetchTrackedToSturdytrunk(accessToken, event.GetRef())).
-		Git(func(repo vcs.Repo) error {
+		GitWrite(vcs_github.FetchTrackedToSturdytrunk(accessToken, event.GetRef())).
+		GitWrite(func(repo vcs.RepoGitWriter) error {
 			logger.Info("listing imported changes")
 
 			// ListImportedChanges lists the latest 50 commits

--- a/api/pkg/github/enterprise/service/pull_request.go
+++ b/api/pkg/github/enterprise/service/pull_request.go
@@ -13,11 +13,11 @@ import (
 	"getsturdy.com/api/pkg/change/message"
 	vcs_change "getsturdy.com/api/pkg/change/vcs"
 	"getsturdy.com/api/pkg/codebase"
+	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/github"
 	"getsturdy.com/api/pkg/github/enterprise/client"
 	"getsturdy.com/api/pkg/github/enterprise/vcs"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
-	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/workspace"
 	vcsvcs "getsturdy.com/api/vcs"
 
@@ -370,7 +370,7 @@ func (svc *Service) prepareBranchForPullRequestWithView(prBranchName string, ws 
 
 	var resSha string
 
-	exec := svc.executorProvider.New().Read(func(r vcsvcs.RepoReader) error {
+	exec := svc.executorProvider.New().FileReadGitWrite(func(r vcsvcs.RepoReaderGitWriter) error {
 		treeID, err := vcs_change.CreateChangesTreeFromPatches(svc.logger, r, ws.CodebaseID, patchIDs)
 		if err != nil {
 			return err
@@ -419,7 +419,7 @@ func (svc *Service) prepareBranchForPullRequestFromSnapshot(ctx context.Context,
 
 	var resSha string
 
-	exec := svc.executorProvider.New().Git(func(r vcsvcs.Repo) error {
+	exec := svc.executorProvider.New().GitWrite(func(r vcsvcs.RepoGitWriter) error {
 		sha, err := r.CreateNewCommitBasedOnCommit(prBranchName, snapshot.CommitID, signature, commitMessage)
 		if err != nil {
 			return err

--- a/api/pkg/github/enterprise/service/service.go
+++ b/api/pkg/github/enterprise/service/service.go
@@ -160,7 +160,7 @@ func (s *Service) Push(ctx context.Context, gitHubRepository *github.GitHubRepos
 
 	// Push in a git executor context
 	var userVisibleError string
-	if err := s.executorProvider.New().Git(func(repo vcs.Repo) error {
+	if err := s.executorProvider.New().GitWrite(func(repo vcs.RepoGitWriter) error {
 		userVisibleError, err = github_vcs.PushTrackedToGitHub(
 			logger,
 			repo,

--- a/api/pkg/github/enterprise/service/service_import.go
+++ b/api/pkg/github/enterprise/service/service_import.go
@@ -107,8 +107,8 @@ func (svc *Service) importPullRequest(codebaseID, userID string, gitHubPR *gh.Pu
 
 	// Fetch to trunk
 	fetchTrunkExec := svc.executorProvider.New().
-		Git(github_vcs.FetchBranchWithRefspec(accessToken, refspec)).
-		Git(func(repo vcs.Repo) error {
+		GitWrite(github_vcs.FetchBranchWithRefspec(accessToken, refspec)).
+		GitWrite(func(repo vcs.RepoGitWriter) error {
 			// Create the workspace branch
 			if err := repo.CreateNewBranchOnHEAD(workspaceID); err != nil {
 				return fmt.Errorf("failed to create workspace branch")
@@ -184,7 +184,7 @@ func (svc *Service) importPullRequest(codebaseID, userID string, gitHubPR *gh.Pu
 	}
 
 	// Create a snapshot
-	makeSnapshotExec := svc.executorProvider.New().Read(func(repo vcs.RepoReader) error {
+	makeSnapshotExec := svc.executorProvider.New().FileReadGitWrite(func(repo vcs.RepoReaderGitWriter) error {
 		wsHead, err := repo.BranchCommitID(importedTemporaryBranchName)
 		if err != nil {
 			return fmt.Errorf("failed to get head of imported branch: %w", err)

--- a/api/pkg/github/graphql/enterprise/codebase_github_integration_import.go
+++ b/api/pkg/github/graphql/enterprise/codebase_github_integration_import.go
@@ -52,7 +52,7 @@ func (r *codebaseGitHubIntegrationRootResolver) CreateWorkspaceFromGitHubBranch(
 
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/heads/import-branch-%s", args.Input.BranchName, args.Input.BranchName)
 	if err := r.gitExecutorProvider.New().
-		Git(github_vcs.FetchBranchWithRefspec(accessToken, refspec)).
+		GitWrite(github_vcs.FetchBranchWithRefspec(accessToken, refspec)).
 		ExecTrunk(codebaseID, "fetchGithubBranch"); err != nil {
 		return nil, gqlerrors.Error(err)
 	}

--- a/api/pkg/snapshots/vcs/timeline.go
+++ b/api/pkg/snapshots/vcs/timeline.go
@@ -44,14 +44,14 @@ func snapshotOptions(opts ...SnapshotOption) *SnapshotOptions {
 	return options
 }
 
-func snapshotPatchIDs(logger *zap.Logger, repo vcs.Repo, options *SnapshotOptions) ([]string, error) {
+func snapshotPatchIDs(logger *zap.Logger, repo vcs.RepoGitReader, options *SnapshotOptions) ([]string, error) {
 	if options.patchIDsFilter != nil {
 		return *options.patchIDsFilter, nil
 	}
 	return allPatchIDs(logger, repo)
 }
 
-func allPatchIDs(logger *zap.Logger, repo vcs.Repo) ([]string, error) {
+func allPatchIDs(logger *zap.Logger, repo vcs.RepoGitReader) ([]string, error) {
 	diffs, err := repo.CurrentDiffNoIndex()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current diff: %w", err)
@@ -74,7 +74,7 @@ func allPatchIDs(logger *zap.Logger, repo vcs.Repo) ([]string, error) {
 	return patchIDs, nil
 }
 
-func SnapshotOnViewRepo(logger *zap.Logger, repo vcs.RepoReader, codebaseID, snapshotID string, opts ...SnapshotOption) (string, error) {
+func SnapshotOnViewRepo(logger *zap.Logger, repo vcs.RepoReaderGitWriter, codebaseID, snapshotID string, opts ...SnapshotOption) (string, error) {
 	start := time.Now()
 
 	options := snapshotOptions(opts...)
@@ -128,7 +128,7 @@ func SnapshotOnViewRepo(logger *zap.Logger, repo vcs.RepoReader, codebaseID, sna
 	return snapshotCommitID, nil
 }
 
-func SnapshotOnTrunk(repo vcs.Repo, workspaceID, snapshotID string, opts ...SnapshotOption) (string, error) {
+func SnapshotOnTrunk(repo vcs.RepoGitWriter, workspaceID, snapshotID string, opts ...SnapshotOption) (string, error) {
 	if snapshotID == "" {
 		return "", errors.New("snapshotID is not set")
 	}
@@ -156,7 +156,7 @@ func SnapshotOnTrunk(repo vcs.Repo, workspaceID, snapshotID string, opts ...Snap
 	return newCommitID, nil
 }
 
-func SnapshotOnExistingCommit(repo vcs.Repo, snapshotID, existingCommitID string) (string, error) {
+func SnapshotOnExistingCommit(repo vcs.RepoGitWriter, snapshotID, existingCommitID string) (string, error) {
 	if snapshotID == "" {
 		return "", errors.New("snapshotID is not set")
 	}

--- a/api/pkg/suggestions/service/service.go
+++ b/api/pkg/suggestions/service/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"getsturdy.com/api/pkg/analytics"
+	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/notification"
 	sender_notification "getsturdy.com/api/pkg/notification/sender"
 	"getsturdy.com/api/pkg/snapshots"
@@ -15,7 +16,6 @@ import (
 	"getsturdy.com/api/pkg/suggestions"
 	db_suggestions "getsturdy.com/api/pkg/suggestions/db"
 	"getsturdy.com/api/pkg/unidiff"
-	"getsturdy.com/api/pkg/events"
 	vcs_view "getsturdy.com/api/pkg/view/vcs"
 	"getsturdy.com/api/pkg/workspace"
 	service_workspace "getsturdy.com/api/pkg/workspace/service"
@@ -485,7 +485,7 @@ func (s *Service) diffs(
 	}
 
 	var diffs []unidiff.FileDiff
-	if err := s.executorProvider.New().Git(func(repo vcs.Repo) error {
+	if err := s.executorProvider.New().GitRead(func(repo vcs.RepoGitReader) error {
 		gitDiffs, err := repo.DiffCommits(baseSnapshot.CommitID, suggestingSnapshot.CommitID)
 		if err != nil {
 			return fmt.Errorf("failed to get diffs: %w", err)

--- a/api/pkg/workspace/graphql/workspace.go
+++ b/api/pkg/workspace/graphql/workspace.go
@@ -11,13 +11,13 @@ import (
 	service_auth "getsturdy.com/api/pkg/auth/service"
 	db_codebase "getsturdy.com/api/pkg/codebase/db"
 	db_comments "getsturdy.com/api/pkg/comments/db"
+	"getsturdy.com/api/pkg/events"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
 	"getsturdy.com/api/pkg/graphql/resolvers"
 	db_snapshots "getsturdy.com/api/pkg/snapshots/db"
 	"getsturdy.com/api/pkg/snapshots/snapshotter"
 	service_suggestions "getsturdy.com/api/pkg/suggestions/service"
 	db_view "getsturdy.com/api/pkg/view/db"
-	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/workspace"
 	db_workspace "getsturdy.com/api/pkg/workspace/db"
 	service_workspace "getsturdy.com/api/pkg/workspace/service"
@@ -372,7 +372,7 @@ func (r *WorkspaceResolver) updateIsUpToDateWithTrunk() error {
 	}
 
 	var upToDate bool
-	err := r.root.executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+	err := r.root.executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 		// Recalculate
 		var err error
 		upToDate, err = vcs.UpToDateWithTrunk(repo, r.w.ID)
@@ -422,7 +422,7 @@ func (r *WorkspaceResolver) HeadChange(ctx context.Context) (resolvers.ChangeRes
 		var newHeadCommitShow bool
 		var newHeadCommitID *string
 
-		err := r.root.executorProvider.New().Git(func(repo vcsvcs.Repo) error {
+		err := r.root.executorProvider.New().GitRead(func(repo vcsvcs.RepoGitReader) error {
 			headCommitID, err := repo.BranchFirstNonMergeCommit(r.w.ID)
 			if errors.Is(err, vcsvcs.ErrCommitNotFound) {
 				// This codebase has no commits, and that's OK

--- a/api/pkg/workspace/service/service_test.go
+++ b/api/pkg/workspace/service/service_test.go
@@ -5,10 +5,10 @@ import (
 
 	"getsturdy.com/api/pkg/analytics/disabled"
 	workers_ci "getsturdy.com/api/pkg/ci/workers"
+	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/internal/inmemory"
 	"getsturdy.com/api/pkg/queue"
 	"getsturdy.com/api/pkg/snapshots/snapshotter"
-	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/vcs"
 	"getsturdy.com/api/vcs/executor"
 	"getsturdy.com/api/vcs/provider"
@@ -66,7 +66,7 @@ func setup(t *testing.T) *testCollaborators {
 	}
 }
 
-func (c *testCollaborators) createCodebase(t *testing.T, id string) vcs.Repo {
+func (c *testCollaborators) createCodebase(t *testing.T, id string) vcs.RepoGitWriter {
 	repoPath := c.repoProvider.TrunkPath(id)
 	repo, err := vcs.CreateBareRepoWithRootCommit(repoPath)
 	assert.NoError(t, err)

--- a/api/pkg/workspace/vcs/up_to_date.go
+++ b/api/pkg/workspace/vcs/up_to_date.go
@@ -4,7 +4,7 @@ import (
 	"getsturdy.com/api/vcs"
 )
 
-func UpToDateWithTrunk(repo vcs.Repo, workspaceID string) (bool, error) {
+func UpToDateWithTrunk(repo vcs.RepoGitReader, workspaceID string) (bool, error) {
 	trunkHEAD, err := repo.BranchCommitID("sturdytrunk")
 	if err != nil {
 		// If sturdytrunk doesn't exist (such as when an empty repository has been imported), treat it as up to date

--- a/api/pkg/workspace/vcs/vcs.go
+++ b/api/pkg/workspace/vcs/vcs.go
@@ -6,14 +6,14 @@ import (
 	"getsturdy.com/api/vcs"
 )
 
-func Create(repo vcs.Repo, workspaceID string) error {
+func Create(repo vcs.RepoGitWriter, workspaceID string) error {
 	if err := repo.CreateNewBranchOnHEAD(workspaceID); err != nil {
 		return fmt.Errorf("failed to create workspaceID %s: %w", workspaceID, err)
 	}
 	return nil
 }
 
-func CreateAtChange(repo vcs.Repo, workspaceID, changeID string) error {
+func CreateAtChange(repo vcs.RepoGitWriter, workspaceID, changeID string) error {
 	if err := repo.CreateNewBranchAt(workspaceID, changeID); err != nil {
 		return fmt.Errorf("failed to create workspaceID %s: %w", workspaceID, err)
 	}

--- a/api/vcs/executor/locker.go
+++ b/api/vcs/executor/locker.go
@@ -91,3 +91,18 @@ func (l *locker) key(codebaseID string, viewID *string) string {
 	}
 	return fmt.Sprintf("%s/%s", codebaseID, *viewID)
 }
+
+func (l *locker) GetInMemory(codebaseID string, viewID *string) lock {
+	key := l.key(codebaseID, viewID) + "-inmemory"
+
+	l.locksGuard.Lock()
+	defer l.locksGuard.Unlock()
+
+	if m, ok := l.locks[key]; ok {
+		return m
+	}
+
+	mutex := &mutexLock{&sync.RWMutex{}}
+	l.locks[key] = mutex
+	return mutex
+}


### PR DESCRIPTION
<p>api/vcs/executor: split Repo into RepoGitReader and RepoGitWriter</p><p>Both are now protected by a RWMutex.</p><p>Added three new schedule functions, for RepoGitReader, RepoGitWriter, and a combination of RepoGitWriter and RepoReader.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ea9b03f4-f8c5-4b89-8b11-c79305f3ab10) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
