### PR TITLE
rm aws dependency from enterprise

### DIFF
--- a/web/src/docker.ts
+++ b/web/src/docker.ts
@@ -1,4 +1,4 @@
-export const DOCKER_ONELINER = `docker run --interactive --tty \\
+export const DOCKER_ONELINER = `docker run --interactive \\
     --pull always \\
     --publish 30080:80 --publish 30022:22 \\
     --volume "$HOME/.sturdydata:/var/data" \\


### PR DESCRIPTION
<p>web/docs: docker oneliner must not use —tty to make ctrl-c work</p>

---

This PR was created from Nikita Galaiko's (ngalaiko) [workspace](https://getsturdy.com/sturdy-zyTDsnY/f8fa0c2a-e6ff-4c03-9c23-bc914a63a8f7) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
