### PR TITLE
Kiril's Workspace

### DIFF
--- a/web/src/pages/docs/HowToSetupSturdyWithGithub.vue
+++ b/web/src/pages/docs/HowToSetupSturdyWithGithub.vue
@@ -60,6 +60,32 @@
           workspaces so that you can get the code with one click. This will work even if others on
           the team are not using Sturdy.
         </p>
+
+        <h1 id="source-of-truth">Source of truth</h1>
+        <p>
+          When GitHub repositories are connected to Sturdy, this is <strong>more</strong> than just
+          an import at a point in time. Connected repositories can be configured in multiple ways:
+        </p>
+        <ol>
+          <li>
+            <strong>GitHub</strong> as the source of truth &mdash; In this mode, Sturdy will follow
+            changes happening on GitHub. Changes made in Sturdy are merged through GitHub Pull
+            Requests. When Pull Requests are merged on GitHub, they will automatically be synced to
+            Sturdy. This works even when changes are made outside of Sturdy. In this mode, some team
+            members can develop through Sturdy without affecting others who use GitHub directly.
+          </li>
+          <li>
+            <strong>Sturdy</strong> as the source of truth &mdash; In this mode, the state on GitHub
+            follows Sturdy. After a change is shared on Sturdy, it will be pushed to the HEAD branch
+            on GitHub. Changes made directly on GitHub will not be synced to Sturdy. In this mode
+            all development happens through Sturdy.
+          </li>
+          <li>
+            <strong>Disabled</strong> &mdash; The connection can be disabled, in which case the copy
+            of the code on Sturdy and GitHub will diverge.
+          </li>
+        </ol>
+        <p>By default, connected repositories use GitHub as the source of truth.</p>
       </div>
     </template>
   </DocumentationWithTableOfContents>

--- a/web/src/pages/docs/UsingSturdy.vue
+++ b/web/src/pages/docs/UsingSturdy.vue
@@ -35,7 +35,43 @@
           </li>
         </ol>
 
-        <h2 id="import-a-repository">Setup Sturdy on a GitHub repository</h2>
+        <h2 id="first-codebase">Your first codebase</h2>
+        <p>In Sturdy you can create a codebase in two ways:</p>
+        <ul>
+          <li>Create new codebases [<a href="#create-a-codebase">go to</a>]</li>
+          <li>
+            Connect one or multiple existing repositories from GitHub [<a
+              href="#import-a-repository"
+              >go to</a
+            >]
+          </li>
+        </ul>
+
+        <DocsInfoBox>
+          If you are running a self-hosted Sturdy instance and would like to connect a GitHub
+          repository, you will need to first perform additional setup.
+          <br />
+          Follow
+          <router-link :to="{ name: 'v2DocsSelfHosted', hash: '#setup-github-integration' }"
+            >this guide</router-link
+          >
+          before continuing.
+        </DocsInfoBox>
+
+        <h3 id="create-a-codebase">Create a Sturdy standalone codebase</h3>
+        <ol>
+          <li>Click on the three dots icon in the top left corner and select "New codebase"</li>
+          <li>Type in a codebase name and press "Create"</li>
+        </ol>
+
+        <h3 id="import-a-repository">Setup Sturdy on a GitHub repository</h3>
+        <p>
+          Repositories imported from GitHub will remain up-to-date with changes made outside of
+          Sturdy (<router-link
+            :to="{ name: 'v2DocsHowToSetupSturdyWithGitHub', hash: '#source-of-truth' }"
+            >Read more</router-link
+          >).
+        </p>
         <ol>
           <li>Click on the three dots icon in the top left corner and select "Settings"</li>
           <li>Go to the GitHub-tab</li>


### PR DESCRIPTION
<p>web/docs: Update the ‘using Sturdy’ tutorial to highlight the need to setup GitHub integration if the user is self-hosting. Alternative of creating a non-connected codebase is provided</p>

---

This PR was created from Kiril's (krlvi) [workspace](https://getsturdy.com/sturdy-zyTDsnY/9fc51cc9-b47d-4522-ad85-22138a7e2a1a) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
