### PR TITLE
web/sturdy: Don’t load Navbar if it’s the app rendering

### DIFF
--- a/web/src/Sturdy.vue
+++ b/web/src/Sturdy.vue
@@ -40,7 +40,10 @@
 
             <!-- Main area -->
             <main class="md:pl-64 flex flex-1 flex-col">
-              <IndexNavbar v-if="authenticationIsLoaded && !authenticated" :narrow="'true'" />
+              <IndexNavbar
+                v-if="!appEnvironment && authenticationIsLoaded && !authenticated"
+                :narrow="'true'"
+              />
 
               <AppTitleBarSpacer
                 fixed


### PR DESCRIPTION
<p>web/sturdy: Don’t load Navbar if it’s the app rendering it</p>

---

This PR was created from Kiril Videlov's (krlvi) [workspace](https://getsturdy.com/sturdy-zyTDsnY/0ab52c76-053c-4fa5-ac67-bed625a4e3d1) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
