### PR TITLE
Revert api/pkg/downloads: use the correct allower for zip and tar downloads

### DIFF
--- a/api/pkg/change/downloads/enterprise/cloud/graphql/graphql.go
+++ b/api/pkg/change/downloads/enterprise/cloud/graphql/graphql.go
@@ -3,13 +3,12 @@ package graphql
 import (
 	"context"
 
-	"github.com/graph-gophers/graphql-go"
-
 	service_auth "getsturdy.com/api/pkg/auth/service"
 	"getsturdy.com/api/pkg/change"
 	service_downloads "getsturdy.com/api/pkg/change/downloads/enterprise/cloud/service"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
 	"getsturdy.com/api/pkg/graphql/resolvers"
+	"github.com/graph-gophers/graphql-go"
 )
 
 type ContentsDownloadURLRootResolver struct {
@@ -27,15 +26,15 @@ func New(
 	}
 }
 
-func (r *ContentsDownloadURLRootResolver) InternalContentsDownloadTarGzUrl(ctx context.Context, change *change.Change, changeCommit *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
-	return r.download(ctx, change, changeCommit, service_downloads.ArchiveFormatTarGz)
+func (r *ContentsDownloadURLRootResolver) InternalContentsDownloadTarGzUrl(ctx context.Context, change *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
+	return r.download(ctx, change, service_downloads.ArchiveFormatTarGz)
 }
 
-func (r *ContentsDownloadURLRootResolver) InternalContentsDownloadZipUrl(ctx context.Context, change *change.Change, changeCommit *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
-	return r.download(ctx, change, changeCommit, service_downloads.ArchiveFormatZip)
+func (r *ContentsDownloadURLRootResolver) InternalContentsDownloadZipUrl(ctx context.Context, change *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
+	return r.download(ctx, change, service_downloads.ArchiveFormatZip)
 }
 
-func (r *ContentsDownloadURLRootResolver) download(ctx context.Context, change *change.Change, changeCommit *change.ChangeCommit, format service_downloads.ArchiveFormat) (resolvers.ContentsDownloadUrlResolver, error) {
+func (r *ContentsDownloadURLRootResolver) download(ctx context.Context, change *change.ChangeCommit, format service_downloads.ArchiveFormat) (resolvers.ContentsDownloadUrlResolver, error) {
 	if err := r.authService.CanRead(ctx, change); err != nil {
 		return nil, gqlerrors.Error(err)
 	}
@@ -45,7 +44,7 @@ func (r *ContentsDownloadURLRootResolver) download(ctx context.Context, change *
 		return nil, gqlerrors.Error(err)
 	}
 
-	url, err := r.service.CreateArchive(ctx, allower, change.CodebaseID, changeCommit.CommitID, format)
+	url, err := r.service.CreateArchive(ctx, allower, change.CodebaseID, change.CommitID, format)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}

--- a/api/pkg/change/downloads/graphql/resolver.go
+++ b/api/pkg/change/downloads/graphql/resolver.go
@@ -14,10 +14,10 @@ func New() resolvers.ContentsDownloadUrlRootResolver {
 	return &ContentsDownloadURLRootResolver{}
 }
 
-func (*ContentsDownloadURLRootResolver) InternalContentsDownloadTarGzUrl(context.Context, *change.Change, *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
+func (*ContentsDownloadURLRootResolver) InternalContentsDownloadTarGzUrl(context.Context, *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
 	return nil, errors.ErrNotImplemented
 }
 
-func (*ContentsDownloadURLRootResolver) InternalContentsDownloadZipUrl(context.Context, *change.Change, *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
+func (*ContentsDownloadURLRootResolver) InternalContentsDownloadZipUrl(context.Context, *change.ChangeCommit) (resolvers.ContentsDownloadUrlResolver, error) {
 	return nil, errors.ErrNotImplemented
 }

--- a/api/pkg/change/graphql/resolver.go
+++ b/api/pkg/change/graphql/resolver.go
@@ -260,7 +260,7 @@ func (r *ChangeResolver) DownloadTarGz(ctx context.Context) (resolvers.ContentsD
 	if r.changeOnTrunkErr != nil {
 		return nil, gqlerrors.Error(r.changeOnTrunkErr)
 	}
-	return r.root.downloadsResovler.InternalContentsDownloadTarGzUrl(ctx, &r.ch, &r.changeOnTrunk)
+	return r.root.downloadsResovler.InternalContentsDownloadTarGzUrl(ctx, &r.changeOnTrunk)
 }
 
 func (r *ChangeResolver) DownloadZip(ctx context.Context) (resolvers.ContentsDownloadUrlResolver, error) {
@@ -271,5 +271,5 @@ func (r *ChangeResolver) DownloadZip(ctx context.Context) (resolvers.ContentsDow
 	if r.changeOnTrunkErr != nil {
 		return nil, gqlerrors.Error(r.changeOnTrunkErr)
 	}
-	return r.root.downloadsResovler.InternalContentsDownloadZipUrl(ctx, &r.ch, &r.changeOnTrunk)
+	return r.root.downloadsResovler.InternalContentsDownloadZipUrl(ctx, &r.changeOnTrunk)
 }

--- a/api/pkg/graphql/resolvers/change.go
+++ b/api/pkg/graphql/resolvers/change.go
@@ -71,8 +71,8 @@ type HunkResolver interface {
 
 type ContentsDownloadUrlRootResolver interface {
 	// Internal
-	InternalContentsDownloadTarGzUrl(context.Context, *change.Change, *change.ChangeCommit) (ContentsDownloadUrlResolver, error)
-	InternalContentsDownloadZipUrl(context.Context, *change.Change, *change.ChangeCommit) (ContentsDownloadUrlResolver, error)
+	InternalContentsDownloadTarGzUrl(context.Context, *change.ChangeCommit) (ContentsDownloadUrlResolver, error)
+	InternalContentsDownloadZipUrl(context.Context, *change.ChangeCommit) (ContentsDownloadUrlResolver, error)
 }
 
 type ContentsDownloadUrlResolver interface {


### PR DESCRIPTION
<p>api/pkg/downloads: get allower by changecommit</p>

---

This PR was created from Nikita Galaiko's (ngalaiko) [workspace](https://getsturdy.com/sturdy-zyTDsnY/2506554f-444c-4052-adb4-48e5d6b7e1f2) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
