### PR TITLE
go workspace

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.17
+
+use (
+    ./api // getsturdy.com/api
+    ./ssh // getsturdy.com/ssh
+)


### PR DESCRIPTION
<p>go: create a <a target="_blank" rel="noopener noreferrer nofollow" href="http://go.work">go.work</a> (for multi-module support in Go 1.18)</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/9f1479e9-353a-4368-a297-197f5cc09471) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
