### PR TITLE
Vanity imports

### DIFF
--- a/web/lambda/index.js
+++ b/web/lambda/index.js
@@ -68,14 +68,17 @@ exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request
 
   // Redirect go-imports of "getsturdy.com/api" to "github.com/sturdy-dev/sturdy"
-  if (request.uri === '/api' && request.querystring === 'go-get=1') {
+  if (
+    (request.uri.startsWith('/api') || request.uri.startsWith('/ssh') || request.uri === '/') &&
+    request.querystring === 'go-get=1'
+  ) {
     const content = `
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="go-import" content="getsturdy.com/api git https://github.com/sturdy-dev/sturdy">
-    <meta name="go-source" content="getsturdy.com/api https://github.com/sturdy-dev/sturdy https://github.com/sturdy-dev/sturdy/tree/master{/dir} https://github.com/sturdy-dev/sturdy/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="getsturdy.com git https://github.com/sturdy-dev/sturdy">
+    <meta name="go-source" content="getsturdy.com https://github.com/sturdy-dev/sturdy https://github.com/sturdy-dev/sturdy/tree/master{/dir} https://github.com/sturdy-dev/sturdy/blob/master{/dir}/{file}#L{line}">
     <title>Hello Gophers!</title>
   </head>
   <body>


### PR DESCRIPTION
<p>web/lambda: make <a target="_blank" rel="noopener noreferrer nofollow" href="http://getsturdy.com/api">getsturdy.com/api</a> go-gettable (requires Go 1.18+)</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/096d0edd-4b25-4a5f-b611-a8ecbcbdef3a) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
