### PR TITLE
Larger GC batches

### DIFF
--- a/api/pkg/snapshots/db/repo.go
+++ b/api/pkg/snapshots/db/repo.go
@@ -114,7 +114,7 @@ func (r *dbrepo) ListUndeletedInCodebase(codebaseID string) ([]*snapshots.Snapsh
 		  AND created_at < NOW() - interval '3 hour'
 		ORDER BY 
 		  created_at DESC
-		LIMIT 100
+		LIMIT 1000
 		`, codebaseID); err != nil {
 		return nil, fmt.Errorf("failed to query table: %w", err)
 	}


### PR DESCRIPTION
<p>api/pkg/snapshots: increase the snapshots gc batch size to 1000 (once per hour)</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ac83b73f-5568-44bc-af8b-db64c50f006d) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
