### PR TITLE
CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,12 +23,12 @@ steps:
   - label: ":docker: :golang: Run unit tests"
     commands:
       - "./download && cd ./tmp_output"
-      - "docker-compose -f ci/docker-compose.yaml -f ci/unit/docker-compose.yaml up --build --exit-code-from runner"
+      - "docker-compose -f ci/docker-compose.yaml -f ci/unit/docker-compose.yaml up --build --exit-code-from runner --remove-orphans"
 
   - label: ":docker: :yarn: Lint and test"
     commands:
       - "./download && cd ./tmp_output"
-      - "export UID && export GID=$(id -g $(whoami)) && docker-compose -f ci/docker-compose.web.yaml up --build --exit-code-from web-runner"
+      - "export UID && export GID=$(id -g $(whoami)) && docker-compose -f ci/docker-compose.web.yaml up --build --exit-code-from web-runner --remove-orphans"
 
   # - label: ":docker: :golang: :yarn: Build oneliner (no push)"
   #   agents:


### PR DESCRIPTION
<p>ci: set —remove-orphans to docker-compose to auto cleanup leftover images on the ci runner</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ac83b73f-5568-44bc-af8b-db64c50f006d) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
