### PR TITLE
Revert api/analytics: add temporary identifiers to backport some groups

### DIFF
--- a/api/pkg/codebase/service/service.go
+++ b/api/pkg/codebase/service/service.go
@@ -76,7 +76,6 @@ func (svc *Service) GetByShortID(ctx context.Context, shortID string) (*codebase
 	if err != nil {
 		return nil, err
 	}
-	svc.analyticsService.IdentifyCodebase(ctx, cb) // todo: remove after most of codebases are identified in posthog
 	return cb, nil
 }
 
@@ -97,10 +96,6 @@ func (svc *Service) ListByOrganization(ctx context.Context, organizationID strin
 	if err != nil {
 		return nil, fmt.Errorf("could not ListByOrganization: %w", err)
 	}
-	for _, cb := range res {
-		svc.analyticsService.IdentifyCodebase(ctx, cb) // todo: remove after most of codebases are identified in posthog
-	}
-
 	return res, nil
 }
 
@@ -122,7 +117,6 @@ func (svc *Service) ListByOrganizationAndUser(ctx context.Context, organizationI
 		case err == nil:
 			res = append(res, cb)
 		}
-		svc.analyticsService.IdentifyCodebase(ctx, cb) // todo: remove after most of codebases are identified in posthog
 	}
 
 	return res, nil

--- a/api/pkg/organization/service/service.go
+++ b/api/pkg/organization/service/service.go
@@ -48,7 +48,6 @@ func (svc *Service) ListByUserID(ctx context.Context, userID string) ([]*organiz
 		if err != nil {
 			return nil, fmt.Errorf("could not get organization by membership: %w", err)
 		}
-		svc.analyticsServcie.IdentifyOrganization(ctx, org) // todo: remove when most of the orgs are identified in the posthog
 		res = append(res, org)
 	}
 
@@ -156,21 +155,19 @@ func (svc *Service) RemoveMember(ctx context.Context, orgID, userID, deletedByUs
 }
 
 func (svc *Service) GetByID(ctx context.Context, organizationID string) (*organization.Organization, error) {
-	org, err := svc.organizationRepository.Get(ctx, organizationID)
+	member, err := svc.organizationRepository.Get(ctx, organizationID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
-	svc.analyticsServcie.IdentifyOrganization(ctx, org) // todo: remove when most of the orgs are identified in the posthog
-	return org, nil
+	return member, nil
 }
 
 func (svc *Service) GetByShortID(ctx context.Context, shortID organization.ShortOrganizationID) (*organization.Organization, error) {
-	org, err := svc.organizationRepository.GetByShortID(ctx, shortID)
+	member, err := svc.organizationRepository.GetByShortID(ctx, shortID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization: %w", err)
 	}
-	svc.analyticsServcie.IdentifyOrganization(ctx, org) // todo: remove when most of the orgs are identified in the posthog
-	return org, nil
+	return member, nil
 }
 
 func (svc *Service) GetMemberByUserIDAndOrganizationID(ctx context.Context, userID, organizationID string) (*organization.Member, error) {


### PR DESCRIPTION
<p>api/analytics: revert posthog group</p>

---

This PR was created from Nikita Galaiko's (ngalaiko) [workspace](https://getsturdy.com/sturdy-zyTDsnY/69dba296-17b7-4a73-81a4-160d4a2d1612) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
