### PR TITLE
GitHub error with navigation

### DIFF
--- a/web/src/layouts/ElectronNavigation.vue
+++ b/web/src/layouts/ElectronNavigation.vue
@@ -1,0 +1,36 @@
+<template>
+  <main class="flex flex-1 flex-col">
+    <AppTitleBarSpacer
+      fixed
+      pad-right="1rem"
+      class="bg-gray-50 border-b left-0 right-0"
+      :class="[appEnvironment?.platform === 'win32' ? 'border-black' : '']"
+    >
+      <div class="flex-1 flex flex-row justify-between gap-8 items-center">
+        <AppTitleBarSpacer v-slot="{ ipc }" pad-left="1rem">
+          <AppHistoryNavigationButtons :ipc="ipc" class="flex" />
+        </AppTitleBarSpacer>
+
+        <AppMutagenStatus class="flex-1" />
+        <AppShareButton class="flex-shrink-0" />
+      </div>
+    </AppTitleBarSpacer>
+
+    <!-- Primary column -->
+    <section
+      class="flex-1 flex flex-col overflow-x-auto"
+      :class="[appEnvironment ? 'spacer-padding' : '']"
+    >
+      <slot></slot>
+    </section>
+  </main>
+</template>
+
+<script lang="ts" setup>
+import AppTitleBarSpacer from '../components/AppTitleBarSpacer.vue'
+import AppHistoryNavigationButtons from '../components/AppHistoryNavigationButtons.vue'
+import AppMutagenStatus from '../components/AppMutagenStatus.vue'
+import AppShareButton from '../components/AppShareButton.vue'
+
+const appEnvironment = window.appEnvironment
+</script>

--- a/web/src/pages/SetupGithub.vue
+++ b/web/src/pages/SetupGithub.vue
@@ -1,32 +1,41 @@
 <template>
-  <PaddedApp>
-    <div v-if="show_redirected_to_app">
-      <div class="p-3 pt-32 flex flex-col gap-5 items-center justify-center">
-        <img src="../assets/Web/Duck/DuckCap256.png" class="h-16 w-16" alt="Sturdy Duck Logo" />
+  <ElectronNavigation>
+    <PaddedApp>
+      <div v-if="show_redirected_to_app">
+        <div class="p-3 pt-32 flex flex-col gap-5 items-center justify-center">
+          <img src="../assets/Web/Duck/DuckCap256.png" class="h-16 w-16" alt="Sturdy Duck Logo" />
 
-        <h1 class="text-3xl font-bold">Opening App...</h1>
+          <h1 class="text-3xl font-bold">Opening App...</h1>
 
-        <p class="max-w-md text-center">
-          We're trying to open this link up in your Sturdy app!<br />Please hang tight!
-          <router-link class="text-yellow-600 underline" :to="{ name: 'home' }">
-            Continue to Sturdy
-          </router-link>
-          .
-        </p>
+          <p class="max-w-md text-center">
+            We're trying to open this link up in your Sturdy app!<br />Please hang tight!
+            <router-link class="text-yellow-600 underline" :to="{ name: 'home' }">
+              Continue to Sturdy
+            </router-link>
+            .
+          </p>
 
-        <Spinner class="w-7 h-7 text-yellow-600" />
+          <Spinner class="w-7 h-7 text-yellow-600" />
+        </div>
       </div>
-    </div>
-    <Banner v-else-if="show_oauth_went_wrong" status="error">
-      Something went wrong connecting to GitHub, please try again!
-    </Banner>
-    <Banner v-else status="info">
-      <div class="inline-flex">
-        <span>Setting up...</span>
-        <Spinner class="ml-3" />
+      <div v-else-if="show_oauth_went_wrong" class="flex flex-col space-y-4">
+        <Banner status="error">
+          Something went wrong connecting to GitHub, please try again!
+        </Banner>
+        <div>
+          <RouterLinkButton color="green" :to="{ name: 'home' }"
+            >Take me back to safety</RouterLinkButton
+          >
+        </div>
       </div>
-    </Banner>
-  </PaddedApp>
+      <Banner v-else status="info">
+        <div class="inline-flex">
+          <span>Setting up...</span>
+          <Spinner class="ml-3" />
+        </div>
+      </Banner>
+    </PaddedApp>
+  </ElectronNavigation>
 </template>
 
 <script lang="ts">
@@ -36,6 +45,8 @@ import { useRoute, useRouter } from 'vue-router'
 import { Banner } from '../atoms'
 import Spinner from '../components/shared/Spinner.vue'
 import PaddedApp from '../layouts/PaddedApp.vue'
+import ElectronNavigation from '../layouts/ElectronNavigation.vue'
+import RouterLinkButton from '../components/shared/RouterLinkButton.vue'
 
 const openInAppUrl = (): string | undefined => {
   let searchParams = new URLSearchParams(location.search)
@@ -61,7 +72,7 @@ const openInAppUrl = (): string | undefined => {
 }
 
 export default defineComponent({
-  components: { PaddedApp, Banner, Spinner },
+  components: { ElectronNavigation, PaddedApp, Banner, Spinner, RouterLinkButton },
   setup() {
     let route = useRoute()
     let router = useRouter()


### PR DESCRIPTION
<p>web/SetupGitHub: show electron navigation (back/forward history buttons etc) on the GitHub setup page.</p><p>Test with: “open sturdy-dev:///setup-github”</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ac83b73f-5568-44bc-af8b-db64c50f006d) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
