### PR TITLE
app: Make the subprocess window to not pop up

### DIFF
--- a/app/src/mutagen/Daemon.ts
+++ b/app/src/mutagen/Daemon.ts
@@ -81,7 +81,7 @@ export class MutagenDaemon extends TypedEventEmitter<MutagenDaemonEvents> {
 
   async onRunning() {
     if (!this.isRunning) {
-      await new Promise<void>((r) => this.once('session-manager-initialized', r))
+      await new Promise<void>((resolve) => this.once('session-manager-initialized', resolve))
     }
   }
 
@@ -144,7 +144,7 @@ export class MutagenDaemon extends TypedEventEmitter<MutagenDaemonEvents> {
     }
     const process = this.#process
     process.kill(signal)
-    await new Promise((r) => process.once('exit', r))
+    await new Promise((resolve) => process.once('exit', resolve))
   }
 
   async deleteDir() {

--- a/app/src/mutagen/Executable.ts
+++ b/app/src/mutagen/Executable.ts
@@ -64,6 +64,7 @@ export class MutagenExecutable {
         ...(options.env ?? process.env),
       },
       stdio,
+      windowsHide: true, // make sure that a subprocess window won't pop up
     }
   }
 
@@ -80,34 +81,42 @@ export class MutagenExecutable {
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>
   ): [proc: ChildProcessByStdio<Writable, Readable, Readable>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioNull>
   ): [proc: ChildProcessByStdio<Writable, Readable, null>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioPipe>
   ): [proc: ChildProcessByStdio<Writable, null, Readable>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>
   ): [proc: ChildProcessByStdio<null, Readable, Readable>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioNull>
   ): [proc: ChildProcessByStdio<Writable, null, null>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioNull>
   ): [proc: ChildProcessByStdio<null, Readable, null>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioPipe>
   ): [proc: ChildProcessByStdio<null, null, Readable>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioNull>
   ): [proc: ChildProcessByStdio<null, null, null>, onExit: Promise<void>]
+
   execute(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<any, any, any>
@@ -143,34 +152,42 @@ export class MutagenExecutable {
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>
   ): ChildProcessByStdio<Writable, Readable, Readable>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioNull>
   ): ChildProcessByStdio<Writable, Readable, null>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioPipe>
   ): ChildProcessByStdio<Writable, null, Readable>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>
   ): ChildProcessByStdio<null, Readable, Readable>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioPipe, StdioNull, StdioNull>
   ): ChildProcessByStdio<Writable, null, null>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioNull>
   ): ChildProcessByStdio<null, Readable, null>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioPipe>
   ): ChildProcessByStdio<null, null, Readable>
+
   spawn(
     args: readonly string[],
     options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioNull>
   ): ChildProcessByStdio<null, null, null>
+
   spawn(args: readonly string[], options: SpawnOptionsWithStdioTuple<any, any, any>): ChildProcess {
     const spawnOpts = this.#decorateSpawnOptions(options)
     this.#logger.log('spawn', {


### PR DESCRIPTION
<ul><li><p>Renamed ‘r’ on Promises to ‘resolve’ according with ESlint standards naming.</p></li><li><p>Added windowsHide flag to true, when decorating the spawn options to execute the subprocess.</p></li><li><p>White breaklines added automatically after the yarn formatting</p></li></ul>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/857914a0-4bdc-4d70-b054-490f0ab05aa6) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
