### PR TITLE
app: build linux

### DIFF
--- a/app/build-common.sh
+++ b/app/build-common.sh
@@ -89,7 +89,7 @@ function build() {
   fi
 
   BUILDER_CONFIG_YML="electron-builder-${OS}-${ARCH}.yml"
-
+  
   yq eval ".publish[0].url |= \"https://autoupdate.getsturdy.com/client$CHANNEL_PATH_SUFFIX/$OS/$ARCH\" | .publish[1].path=\"client$CHANNEL_PATH_SUFFIX/$OS/$ARCH\"" \
     electron-builder.yml > $BUILDER_CONFIG_YML
 
@@ -99,9 +99,9 @@ function build() {
 
   if [ ! -z "$CHANNEL" ]; then
     yq -i eval "
-      .productName += \" $CHANNEL\",
-      .appId += \"$CHANNEL_PATH_SUFFIX\",
-      .extraMetadata.name += \" $CHANNEL\",
+      .productName += \" $CHANNEL\" |
+      .appId += \"$CHANNEL_PATH_SUFFIX\" |
+      .extraMetadata.name += \" $CHANNEL\" |
       .linux.desktop.Name += \" $CHANNEL\"
     " "$BUILDER_CONFIG_YML"
   fi

--- a/app/build-electron-builder.sh
+++ b/app/build-electron-builder.sh
@@ -51,8 +51,8 @@ build darwin arm64
 build windows amd64 zip
 
 # TODO: Enable at some point?
-# build linux amd64
-# build linux arm64
+build linux amd64
+build linux arm64
 
 if ((DO_UPLOAD)); then
 	invalidate_cloudfront "${CHANNEL}"

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -48,9 +48,9 @@ linux:
     Terminal: 'false'
 
   target:
-    - appImage
-    #- snap
-    - deb
+    # - appImage
+    - snap
+    # - deb
 
 dmg:
   background: assets/dmg.png
@@ -58,6 +58,9 @@ dmg:
     width: 658
     height: 498
   sign: true
+
+snap:
+  confinement: 'classic'
 
 nsis:
   menuCategory: false


### PR DESCRIPTION
<ul><li><p>On <a target="_blank" rel="noopener noreferrer nofollow" href="http://build-common.sh">build-common.sh</a> replaced the ‘,’ when appending with ‘|’, duo to the new version of YQ.</p></li><li><p>Now possible to build for Linux. Current target to Snap.</p></li></ul>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/e6f481cd-7b9d-429d-a742-20d2a3749f1e) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
