### PR TITLE
Remove unused Workspaces API

### DIFF
--- a/api/pkg/workspaces/routes/create.go
+++ b/api/pkg/workspaces/routes/create.go
@@ -17,13 +17,6 @@ import (
 
 type CreateRequest struct {
 	CodebaseID string `json:"codebase_id" binding:"required"`
-	Name       string `json:"name"`
-
-	// ChangeID is a commit checksum
-	ChangeID string `json:"change_id"` // change_id and revert_change_id are mutually exclusive
-
-	// RevertChangeID is a commit checksum
-	RevertChangeID string `json:"revert_change_id"` //
 }
 
 func Create(logger *zap.Logger, workspaceService service_workspace.Service, codebaseUserRepo db_codebase.CodebaseUserRepository) func(c *gin.Context) {
@@ -48,13 +41,9 @@ func Create(logger *zap.Logger, workspaceService service_workspace.Service, code
 		}
 
 		ws, err := workspaceService.Create(c.Request.Context(), service_workspace.CreateWorkspaceRequest{
-			UserID:         userID,
-			CodebaseID:     req.CodebaseID,
-			Name:           req.Name,
-			RevertCommitID: req.RevertChangeID,
-			CommitID:       req.ChangeID,
+			UserID:     userID,
+			CodebaseID: req.CodebaseID,
 		})
-
 		if err != nil {
 			logger.Error("failed to create workspace", zap.Error(err))
 			c.AbortWithStatus(http.StatusInternalServerError)


### PR DESCRIPTION
<p>api/pkg/workspaces: cleanup unused arguments from POST /v3/workspaces<br><br>This API is used by the CLI, but it only ever sets codebase_id. All of the other arguments are never set, and can safely be removed.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/a79109b0-f25d-41ba-b5cd-8a1216d71504) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
