### PR TITLE
Large Files

### DIFF
--- a/api/vcs/provider/configuration.go
+++ b/api/vcs/provider/configuration.go
@@ -8,7 +8,7 @@ type Configuration struct {
 }
 
 type GitLFSConfiguration struct {
-	Addr flags.Addr `long:"addr" description:"Git LFS server address" required:"true" default:"localhost:8080"`
+	Addr flags.Addr `long:"addr" description:"Git LFS server address" required:"true" default:"localhost:8888"`
 }
 
 func FromConfiguration(cfg *Configuration) RepoProvider {


### PR DESCRIPTION
<p>api/vcs: fix default configuration port for the Git LFS server</p><p>RudoLFS is running on port 8888 both in the oneliner and in the development Docker Compose.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/48660653-f0b2-40f7-8cdd-ea93d0ae382a) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
