### PR TITLE
App History

### DIFF
--- a/web/src/components/AppHistoryNavigationButtons.vue
+++ b/web/src/components/AppHistoryNavigationButtons.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, watch } from 'vue'
+import { defineComponent, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/vue/solid'
 
@@ -60,13 +60,13 @@ export default defineComponent({
   methods: {
     async back() {
       await this.ipc.goBack()
-      this.canGoForward = true
+      this.canGoForward = await this.ipc.canGoForward()
       this.canGoBack = await this.ipc.canGoBack()
     },
     async forward() {
       await this.ipc.goForward()
       this.canGoForward = await this.ipc.canGoForward()
-      this.canGoBack = true
+      this.canGoBack = await this.ipc.canGoBack()
     },
   },
 })


### PR DESCRIPTION
<p>web/AppHistoryNavigationButtons: always call canGoForward/canGoBackward to calculate the new values after navigation</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/f1be588b-6a00-4d7f-bfde-f147e8a0cf83) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
