### PR TITLE
Changelog: long description texts are rendered on top of each other

### DIFF
--- a/web/src/molecules/ChangelogChange.vue
+++ b/web/src/molecules/ChangelogChange.vue
@@ -16,10 +16,10 @@
         <RelativeTime class="text-sm text-gray-500" :date="createdAt" />
       </div>
 
-      <div class="flex w-full h-full">
+      <div class="flex-1 w-full h-full">
         <span
           v-if="showDescription"
-          class="flex-1 text-sm line-clamp-6"
+          class="flex-1 text-sm line-clamp-12"
           v-html="change.description"
         />
         <span v-else class="flex-1 text-sm line-clamp-1">

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -15,6 +15,9 @@ module.exports = {
         yellow: colors.amber,
         purple: colors.violet,
       },
+      lineClamp:{
+        12: '12'
+      }
     },
   },
   plugins: [


### PR DESCRIPTION
<p>web: added to tailwind config a new size for lineClamp '12'. For the changelog, increased the line clamp for 12, and changed flex to flex-1 to avoid the words to collide.</p>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/0dd358b6-4134-457e-bbac-907d5991daf3) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
