### PR TITLE
EventsReadWriter

### DIFF
--- a/api/pkg/activity/graphql/root.go
+++ b/api/pkg/activity/graphql/root.go
@@ -175,7 +175,7 @@ func (r *root) UpdatedWorkspaceActivity(ctx context.Context) (chan resolvers.Act
 
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case c <- resolver:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/codebase/graphql/codebase.go
+++ b/api/pkg/codebase/graphql/codebase.go
@@ -221,7 +221,7 @@ func (r *CodebaseRootResolver) UpdatedCodebase(ctx context.Context) (<-chan reso
 			}
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case c <- resolver:
 				if didErrorOut {
 					didErrorOut = false

--- a/api/pkg/comments/graphql/resolver.go
+++ b/api/pkg/comments/graphql/resolver.go
@@ -206,7 +206,7 @@ func (r *CommentRootResolver) UpdatedComment(ctx context.Context, args resolvers
 		for _, resolver := range allResolvers {
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case res <- resolver:
 				if didErrorOut {
 					didErrorOut = false

--- a/api/pkg/github/graphql/pr/enterprise/pr_root_resolver.go
+++ b/api/pkg/github/graphql/pr/enterprise/pr_root_resolver.go
@@ -209,7 +209,7 @@ func (r prRootResolver) UpdatedGitHubPullRequest(ctx context.Context, args resol
 		}
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case res <- resolver:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/notification/graphql/root.go
+++ b/api/pkg/notification/graphql/root.go
@@ -274,7 +274,7 @@ func (r *notificationRootResolver) UpdatedNotifications(ctx context.Context) (ch
 			}
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case res <- resolver:
 				if didErrorOut {
 					didErrorOut = false

--- a/api/pkg/onboarding/graphql/resolver.go
+++ b/api/pkg/onboarding/graphql/resolver.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"getsturdy.com/api/pkg/auth"
@@ -73,7 +72,7 @@ func (r *onboardingRootResolver) CompletedOnboardingStep(ctx context.Context) (c
 		if eventType == events.CompletedOnboardingStep {
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case res <- &onboardingStepResolver{
 				step: &onboarding.Step{
 					ID:        reference,

--- a/api/pkg/organization/graphql/resolver.go
+++ b/api/pkg/organization/graphql/resolver.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"getsturdy.com/api/pkg/events"
-	"go.uber.org/zap"
 	"strings"
+
+	"go.uber.org/zap"
+
+	"getsturdy.com/api/pkg/events"
 
 	"github.com/gosimple/slug"
 	"github.com/graph-gophers/graphql-go"
@@ -251,7 +253,7 @@ func (r *organizationRootResolver) UpdatedOrganization(ctx context.Context, args
 			}
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case c <- resolver:
 				if didErrorOut {
 					didErrorOut = false

--- a/api/pkg/presence/graphql/resolver.go
+++ b/api/pkg/presence/graphql/resolver.go
@@ -108,7 +108,7 @@ func (r *presenceRootResolver) UpdatedWorkspacePresence(ctx context.Context, arg
 				r2 := resolver
 				select {
 				case <-ctx.Done():
-					return errors.New("disconnected")
+					return events.ErrClientDisconnected
 				case res <- r2:
 					if didErrorOut {
 						didErrorOut = false

--- a/api/pkg/review/graphql/updated.go
+++ b/api/pkg/review/graphql/updated.go
@@ -32,7 +32,7 @@ func (r *reviewRootResolver) UpdatedReviews(ctx context.Context) (<-chan resolve
 
 		select {
 		case <-ctx.Done():
-			return nil
+			return events.ErrClientDisconnected
 		case c <- resolver:
 		default:
 			r.logger.Named("updatedReviews").Error("dropped event",

--- a/api/pkg/statuses/enterprise/graphql/resolver.go
+++ b/api/pkg/statuses/enterprise/graphql/resolver.go
@@ -95,7 +95,7 @@ func (r *RootResolver) UpdatedGitHubPullRequestStatuses(ctx context.Context, arg
 		resolver := r.InternalStatus(status)
 		select {
 		case <-ctx.Done():
-			return errors.New("disconneted")
+			return events.ErrClientDisconnected
 		case c <- resolver:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/statuses/graphql/updatedChangesStatuses.go
+++ b/api/pkg/statuses/graphql/updatedChangesStatuses.go
@@ -67,7 +67,7 @@ func (r *RootResolver) UpdatedChangesStatuses(ctx context.Context, args resolver
 		resolver := &resolver{status: status, root: r}
 		select {
 		case <-ctx.Done():
-			return errors.New("disconneted")
+			return events.ErrClientDisconnected
 		case c <- resolver:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/suggestions/graphql/root.go
+++ b/api/pkg/suggestions/graphql/root.go
@@ -192,7 +192,7 @@ func (r *RootResolver) UpdatedSuggestion(ctx context.Context, args resolvers.Upd
 
 			select {
 			case <-ctx.Done():
-				return errors.New("disconnected")
+				return events.ErrClientDisconnected
 			case res <- resolver:
 				if didErrorOut {
 					didErrorOut = false

--- a/api/pkg/view/graphql/viewResolver.go
+++ b/api/pkg/view/graphql/viewResolver.go
@@ -170,7 +170,7 @@ func (r *ViewRootResolver) UpdatedViews(ctx context.Context) (chan resolvers.Vie
 		resolver := &Resolver{v: view, root: r}
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case res <- resolver:
 			return nil
 		default:
@@ -222,7 +222,7 @@ func (r *ViewRootResolver) UpdatedView(ctx context.Context, args resolvers.Updat
 
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case res <- resolver:
 			return nil
 		default:

--- a/api/pkg/view/stream/stream.go
+++ b/api/pkg/view/stream/stream.go
@@ -10,10 +10,10 @@ import (
 
 	"getsturdy.com/api/pkg/auth"
 	"getsturdy.com/api/pkg/ctxlog"
+	"getsturdy.com/api/pkg/events"
 	service_suggestions "getsturdy.com/api/pkg/suggestions/service"
 	"getsturdy.com/api/pkg/unidiff"
 	"getsturdy.com/api/pkg/view"
-	"getsturdy.com/api/pkg/events"
 	"getsturdy.com/api/pkg/workspaces"
 	service_workspace "getsturdy.com/api/pkg/workspaces/service"
 
@@ -109,7 +109,7 @@ func Stream(
 	callbackFunc := func(eventType events.EventType, reference string) error {
 		// This can be racy, but that's OK.
 		if disconnected {
-			return fmt.Errorf("user is disconnected")
+			return events.ErrClientDisconnected
 		}
 
 		workspaceUpdated := eventType == events.WorkspaceUpdated && reference == ws.ID

--- a/api/pkg/workspaces/graphql/updatedWorkspace.go
+++ b/api/pkg/workspaces/graphql/updatedWorkspace.go
@@ -2,8 +2,6 @@ package graphql
 
 import (
 	"context"
-	"errors"
-
 	"strings"
 
 	"getsturdy.com/api/pkg/auth"
@@ -90,7 +88,7 @@ func (r *WorkspaceRootResolver) UpdatedWorkspace(ctx context.Context, args resol
 		}
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case c <- resolver:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/workspaces/graphql/updatedWorkspaceDiffs.go
+++ b/api/pkg/workspaces/graphql/updatedWorkspaceDiffs.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-	"errors"
 
 	"getsturdy.com/api/pkg/auth"
 	"getsturdy.com/api/pkg/events"
@@ -52,7 +51,7 @@ func (r *WorkspaceRootResolver) UpdatedWorkspaceDiffs(ctx context.Context, args 
 
 		select {
 		case <-ctx.Done():
-			return errors.New("disconnected")
+			return events.ErrClientDisconnected
 		case c <- diffs:
 			if didErrorOut {
 				didErrorOut = false

--- a/api/pkg/workspaces/watchers/graphql/updated.go
+++ b/api/pkg/workspaces/watchers/graphql/updated.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"getsturdy.com/api/pkg/auth"
+	"getsturdy.com/api/pkg/events"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
 	"getsturdy.com/api/pkg/graphql/resolvers"
-	"getsturdy.com/api/pkg/events"
 
 	"go.uber.org/zap"
 )
@@ -43,7 +43,7 @@ func (r *rootResolver) UpdatedWorkspaceWatchers(ctx context.Context, args resolv
 		resolver := &watcherResolver{Watcher: watcher, Root: r}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("disconnected")
+			return events.ErrClientDisconnected
 		case c <- resolver:
 			if didErorrOut {
 				didErorrOut = false


### PR DESCRIPTION
<p>api/pkg/events: call callback funcs from a go-routine</p><p>This fixes an issue where the the producer and the consumer of events could deadlock each other</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/691a977c-1df1-4ab5-a467-e6246463b295) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
