### PR TITLE
Allow to reconnect github (oauth2 flow again) if somethins is off with the token)

### DIFF
--- a/api/pkg/github/enterprise/client/client.go
+++ b/api/pkg/github/enterprise/client/client.go
@@ -20,6 +20,7 @@ type AppClientProvider func(gitHubAppConfig *config.GitHubAppConfig) (appsClient
 type GitHubClients struct {
 	Repositories RepositoriesClient
 	PullRequests PullRequestsClient
+	Users        UsersClient
 }
 
 type RepositoriesClient interface {
@@ -41,6 +42,10 @@ type PullRequestsClient interface {
 	Edit(ctx context.Context, owner string, repo string, number int, pull *github.PullRequest) (*github.PullRequest, *github.Response, error)
 }
 
+type UsersClient interface {
+	Get(ctx context.Context, user string) (*github.User, *github.Response, error)
+}
+
 // NewInstallationClient creates a client for installationID that's acting on behalf of the app
 func NewInstallationClient(gitHubAppConfig *config.GitHubAppConfig, installationID int64) (tokenClient *GitHubClients, appsClient AppsClient, err error) {
 	jwtTransport, err := ghinstallation.NewAppsTransportKeyFromFile(http.DefaultTransport, gitHubAppConfig.ID, gitHubAppConfig.PrivateKeyPath)
@@ -56,6 +61,7 @@ func NewInstallationClient(gitHubAppConfig *config.GitHubAppConfig, installation
 	return &GitHubClients{
 			Repositories: ghClient.Repositories,
 			PullRequests: ghClient.PullRequests,
+			Users:        ghClient.Users,
 		},
 		appsGhClient.Apps, nil
 }
@@ -73,6 +79,7 @@ func NewPersonalClient(personalOauthToken string) (personalClient *GitHubClients
 	return &GitHubClients{
 		Repositories: client.Repositories,
 		PullRequests: client.PullRequests,
+		Users:        client.Users,
 	}, nil
 }
 

--- a/api/pkg/github/graphql/enterprise/account.go
+++ b/api/pkg/github/graphql/enterprise/account.go
@@ -2,40 +2,46 @@ package enterprise
 
 import (
 	"context"
-
 	"getsturdy.com/api/pkg/github"
+	"getsturdy.com/api/pkg/github/enterprise/client"
 	"getsturdy.com/api/pkg/github/enterprise/db"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
 	"getsturdy.com/api/pkg/graphql/resolvers"
 	"getsturdy.com/api/pkg/users"
-
 	"github.com/graph-gophers/graphql-go"
 )
 
 type GitHubAccountRootResolver struct {
 	gitHubUserRepo db.GitHubUserRepo
+	personalClient client.PersonalClientProvider
 }
 
 func NewGitHubAccountRootResolver(
 	gitHubUserRepo db.GitHubUserRepo,
+	personalClient client.PersonalClientProvider,
 ) *GitHubAccountRootResolver {
 	return &GitHubAccountRootResolver{
 		gitHubUserRepo: gitHubUserRepo,
+		personalClient: personalClient,
 	}
 }
 
 func (r *GitHubAccountRootResolver) InteralByID(_ context.Context, id users.ID) (resolvers.GitHubAccountResolver, error) {
 	githubUser, err := r.gitHubUserRepo.GetByUserID(id)
+
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}
+
 	return &gitHubAccountResolver{
-		githubUser: githubUser,
+		githubUser:     githubUser,
+		personalClient: r.personalClient,
 	}, nil
 }
 
 type gitHubAccountResolver struct {
-	githubUser *github.GitHubUser
+	githubUser     *github.GitHubUser
+	personalClient client.PersonalClientProvider
 }
 
 func (r *gitHubAccountResolver) ID() graphql.ID {
@@ -44,4 +50,15 @@ func (r *gitHubAccountResolver) ID() graphql.ID {
 
 func (r *gitHubAccountResolver) Login() string {
 	return r.githubUser.Username
+}
+
+func (r *gitHubAccountResolver) IsValid(ctx context.Context) bool {
+	personalClient, err := r.personalClient(r.githubUser.AccessToken)
+	if err != nil {
+		return false
+	}
+
+	_, _, err = personalClient.Users.Get(ctx, "")
+
+	return err == nil
 }

--- a/api/pkg/graphql/resolvers/github_account.go
+++ b/api/pkg/graphql/resolvers/github_account.go
@@ -15,4 +15,5 @@ type GitHubAccountRootResolver interface {
 type GitHubAccountResolver interface {
 	ID() graphql.ID
 	Login() string
+	IsValid(ctx context.Context) bool
 }

--- a/api/pkg/graphql/schema/enterprise.graphql
+++ b/api/pkg/graphql/schema/enterprise.graphql
@@ -87,6 +87,7 @@ type CodebaseGitHubIntegration {
 type GitHubAccount {
     id: ID!
     login: String!
+    isValid: Boolean!
 }
 
 enum IntegrationProvider {

--- a/web/src/molecules/GitHubConnectButton.vue
+++ b/web/src/molecules/GitHubConnectButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <LinkButton v-if="!gitHubAccount" :href="github_oauth_url" :color="color">
+  <LinkButton v-if="!gitHubAccount || !gitHubAccount.isValid" :href="github_oauth_url" :color="color">
     {{ notConnectedText }}
   </LinkButton>
   <div v-else class="space-x-2">
@@ -28,6 +28,7 @@ export const GITHUB_ACCOUNT_FRAGMENT = gql`
   fragment GitHubAccount on GitHubAccount {
     id
     login
+    isValid
   }
 `
 

--- a/web/src/organisms/organization/OrganizationSetupGitHub.vue
+++ b/web/src/organisms/organization/OrganizationSetupGitHub.vue
@@ -152,6 +152,7 @@ export const GITHUB_ACCOUNT_FRAGMENT = gql`
   fragment GitHubAccount on GitHubAccount {
     id
     login
+    isValid
   }
 `
 

--- a/web/src/organisms/user/Integrations.vue
+++ b/web/src/organisms/user/Integrations.vue
@@ -8,7 +8,7 @@
       <li class="py-4 flex items-center justify-between">
         <div class="flex flex-col">
           <p class="text-sm font-medium text-gray-900">GitHub</p>
-          <p v-if="user.gitHubAccount" class="text-sm text-gray-500">
+          <p v-if="user.gitHubAccount && user.gitHubAccount.isValid" class="text-sm text-gray-500">
             You're connected to GitHub as
             <a :href="'https://github.com/' + user.gitHubAccount.login">
               {{ user.gitHubAccount.login }}
@@ -55,6 +55,7 @@ export const INTEGRATIONS_USER_FRAGMENT = gql`
     gitHubAccount {
       id
       login
+      isValid
       ...GitHubAccount
     }
   }

--- a/web/src/pages/organization/OrganizationSetupGitHubPage.vue
+++ b/web/src/pages/organization/OrganizationSetupGitHubPage.vue
@@ -75,6 +75,7 @@ export default defineComponent({
             gitHubAccount @include(if: $isGitHubEnabled) {
               id
               login
+              isValid
             }
           }
         }


### PR DESCRIPTION
<p>api: now oauth supports to renovate token when trying to connect a github user. </p><p>api: Now catches the error when doing something with github with a bad token, and can reconnect to github on the settings page. </p><p>Some renaming variables.</p>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/0dd358b6-4134-457e-bbac-907d5991daf3) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
