### PR TITLE
Web: The wrong line number can be highlighted in the search in large files

### DIFF
--- a/web/src/components/differ/Differ.vue
+++ b/web/src/components/differ/Differ.vue
@@ -63,6 +63,7 @@ import type {
   Differ_FileDiffFragment,
   Differ_SuggestionFragment,
 } from './__generated__/Differ'
+import { getIndicesOf } from './DifferHelper'
 
 export const DIFFER_TOP_COMMENT_FRAGMENT = gql`
   fragment Differ_TopComment on TopComment {
@@ -87,25 +88,6 @@ export const DIFFER_SUGGESTION = gql`
   }
   ${DIFFER_FILE_SUGGESTION}
 `
-
-const getIndicesOf = function (searchStr: string, str: string, caseSensitive: boolean): number[] {
-  let searchStrLen = searchStr.length
-  if (searchStrLen === 0) {
-    return []
-  }
-  let startIndex = 0,
-    index,
-    indices = []
-  if (!caseSensitive) {
-    str = str.toLowerCase()
-    searchStr = searchStr.toLowerCase()
-  }
-  while ((index = str.indexOf(searchStr, startIndex)) > -1) {
-    indices.push(index)
-    startIndex = index + searchStrLen
-  }
-  return indices
-}
 
 export default defineComponent({
   components: {

--- a/web/src/components/differ/DifferHelper.spec.ts
+++ b/web/src/components/differ/DifferHelper.spec.ts
@@ -1,0 +1,38 @@
+import {getIndicesOf, searchMatches} from './DifferHelper'
+import {Hunk} from "../../__generated__/types";
+
+describe('DifferHelper', () => {
+  it('get indexes length', () => {
+    const str1 = `diff --git "a/readme.md" "b/readme.md"
+index 48533da..f627f7d 100644
+--- "a/readme.md"
++++ "b/readme.md"
+@@ -1,1 +1,7 @@
+-# testing1
+\\ no newline at end of file
++# testing1
++dsada
++dasda
++testing2
++das
+\\ no newline at end of file
++testing3
++testing4
+\\ no newline at end of file
+`
+    expect(getIndicesOf('testing', str1, false).length).toEqual(5);
+    expect(getIndicesOf('da', str1, false).length).toEqual(4);
+    expect(getIndicesOf('sa', str1, false).length).toEqual(1);
+    expect(getIndicesOf('f', str1, false).length).toEqual(0);
+
+    const n: Hunk = {
+        isApplied: false,
+        isDismissed: false,
+        isOutdated: false,
+        id: "d320fd593ace289810cb0991e437fec054ef34d4215bf8e07a429c17fa1fea36",
+        patch: str1};
+      const m = new Map<string, number[]>();
+      m.set(n.id, getIndicesOf('testing', n.patch, false));
+      expect(searchMatches(m, [n]).size).toEqual(5);
+  })
+})

--- a/web/src/components/differ/DifferHelper.ts
+++ b/web/src/components/differ/DifferHelper.ts
@@ -1,0 +1,104 @@
+import {Hunk} from "../../__generated__/types";
+
+export const getIndicesOf = function (
+  searchStr: string,
+  str: string,
+  caseSensitive: boolean
+): number[] {
+  const searchStrLen = searchStr.length;
+  if (searchStrLen === 0) {
+    return [];
+  }
+  const indices = []
+  if (!caseSensitive) {
+    str = str.toLowerCase();
+    searchStr = searchStr.toLowerCase();
+  }
+  let length = 0, started = false;
+  const lines = str.split('\n');
+  for (const line of lines) {
+    length += line.length + 1;
+    // Conditions to keep forward
+    {
+      if (!started) {
+        if (line.startsWith('@@ ')) {
+          started = true;
+        }
+        continue;
+      } else if (line.includes('no newline at end of file')) {
+        continue;
+      }
+    }
+    let index = 0, startIndex = 0;
+    while ((index = line.indexOf(searchStr, startIndex)) > -1) {
+      const currentIndex = length - line.length < 0 ? 0 : length - line.length;
+      indices.push(currentIndex + index);
+      startIndex = index + searchStrLen;
+    }
+  }
+
+  return indices;
+}
+
+export const searchMatches = function(searchResult: Map<string, number[]> | undefined, hunks: Hunk[]) : Set<string> {
+  const res = new Set<string>();
+
+  if (!searchResult || searchResult.size === 0) {
+    return res;
+  }
+
+  const endsAt = new Map<string, [[number, number]]>();
+
+  for (const hunk of hunks) {
+    let starts = 0, ends = 0, started = false;
+    const lines = hunk.patch.split('\n')
+    for (const line of lines) {
+      starts = ends;
+      ends += line.length + 1; // add trimmed newline
+
+      // Conditions to keep forward
+      {
+        if (!started) {
+          if (line.startsWith('@@ ')) {
+            started = true;
+          }
+          continue;
+        }
+
+        if (line.includes('No newline at end of file')) {
+          continue;
+        }
+      }
+
+      if (!endsAt.has(hunk.id)) {
+        endsAt.set(hunk.id, [[starts, ends]]);
+      } else {
+        const ref = endsAt.get(hunk.id);
+        if (ref) {
+          ref.push([starts, ends]);
+        }
+      }
+    }
+  }
+
+  for (const [hunkID, foundIndexes] of searchResult) {
+    const rangeTuples = endsAt.get(hunkID);
+    if (!rangeTuples) {
+      continue;
+    } else if (rangeTuples.length <= 0) {
+      continue;
+    }
+    for (const foundIndex of foundIndexes) {
+      for (let i = 0; i < rangeTuples.length; i++) {
+        const tuple = rangeTuples[i], starts = tuple[0], ends = tuple[1];
+        if (foundIndex < starts) {
+          break;
+        } else if (foundIndex < ends) {
+          res.add(hunkID + '-' + i);
+          break;
+        }
+      }
+    }
+  }
+  return res;
+}

--- a/web/src/components/workspace/SearchToolbar.vue
+++ b/web/src/components/workspace/SearchToolbar.vue
@@ -27,7 +27,6 @@
             placeholder="Search"
             @keyup.enter="searchKeyUpEnter"
             @keyup.esc="searchStop"
-            @keyup="emitSearch"
           />
         </div>
       </div>
@@ -129,10 +128,12 @@ export default defineComponent({
     searchNext() {
       this.searchCurrentIdx++
       this.searchScrollTo()
+      this.emitSearch()
     },
     searchPrev() {
       this.searchCurrentIdx--
       this.searchScrollTo()
+      this.emitSearch()
     },
     searchScrollTo() {
       let allMatches = document.getElementsByClassName('sturdy-searchmatch')


### PR DESCRIPTION
<p>web: solved the problem where when doing the search, wouldn't retrieve the real indexes. Optimized the search of the found indexes in the ranged indexes. Fixed a small bug where the search toolbar arrows weren't emit the search event.</p>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/9ce83c85-acd9-4fd5-bd11-90ba0ac6048e) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
