### PR TITLE
Avatars

### DIFF
--- a/oneliner/etc/s6-overlay/s6-rc.d/reproxy/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/reproxy/run
@@ -20,4 +20,5 @@ exec reproxy \
   --timeout.keep-alive=60s \
   --timeout.resp-header=60s \
   --timeout.idle-conn=90s \
+  --max=0 \
 	--listen="127.0.0.1:8080"


### PR DESCRIPTION
<p>oneliner/reproxy: disable max request size limits</p><p>This fixes an issue where new avatars could not be uploaded if they where too big.</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/ee1dfa60-3e82-4e5d-9a9d-bebecdc0db91) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
