### PR TITLE
web: Show search by entering / (new keyboard shortcut)

### DIFF
--- a/web/src/components/workspace/SearchToolbar.vue
+++ b/web/src/components/workspace/SearchToolbar.vue
@@ -97,16 +97,21 @@ export default defineComponent({
   methods: {
     globalKeyDown(event) {
       // Available as cmd+k on the web
-      let keys = [
+      let cmdKeys = [
         75, // K
       ]
 
+      const standaloneKeys = ['/']
+
       // Also available as cmd+f in the app
       if (this.isApp) {
-        keys.push(70) // F
+        cmdKeys.push(70) // F
       }
 
-      if (keys.indexOf(event.keyCode) > -1 && (event.ctrlKey || event.metaKey)) {
+      if (
+        (cmdKeys.indexOf(event.keyCode) > -1 && (event.ctrlKey || event.metaKey)) ||
+        standaloneKeys.includes(event.key)
+      ) {
         this.showSearch = true
         event.stopPropagation()
         event.preventDefault()


### PR DESCRIPTION
<p>web: Added an option for standalone keys or with shift to open the search bar. Example: “/” key, on the Portuguese layout only work if the shift is pressed.</p>

---

This PR was created from Joao Araujo's (julienangel) [workspace](https://getsturdy.com/sturdy-zyTDsnY/85fb5279-4c87-4e29-a1a8-3755f10312ff) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
