### PR TITLE
Gustav Westling's Workspace

### DIFF
--- a/api/pkg/github/graphql/pr/enterprise/pr_test.go
+++ b/api/pkg/github/graphql/pr/enterprise/pr_test.go
@@ -549,7 +549,6 @@ func TestPRHighLevel(t *testing.T) {
 			ws, err := workspaceRepo.Get(workspaceID)
 			assert.NoError(t, err)
 			assert.Nil(t, ws.UpToDateWithTrunk)
-			assert.Empty(t, ws.DraftDescription) // draft message is reset after push event
 
 			// The workspace should no longer have any comments
 			wsResolver, err = workspaceResolver.Workspace(ctx, resolvers.WorkspaceArgs{ID: gqlID, AllowArchived: b(true)})


### PR DESCRIPTION
<p>api/pkg/github: remove untrue test condition</p><p>Workspace descriptions are no longer reset on push</p>

---

This PR was created from Gustav Westling's (zegl) [workspace](https://getsturdy.com/sturdy-zyTDsnY/d15fdfa2-7906-45df-8236-071d2061b7c7) on [Sturdy](https://getsturdy.com/).

Join your team, and code and collaborate on Sturdy, [join now!](https://getsturdy.com/get-started/github)

Update this PR by making changes through Sturdy.
