### PR TITLE
web/Git: properly build webhook url

### DIFF
--- a/web/src/pages/settings/integrations/add/git/Git.vue
+++ b/web/src/pages/settings/integrations/add/git/Git.vue
@@ -170,6 +170,7 @@ import { useCreateOrUpdateCodebaseRemote } from '../../../../../mutations/useCre
 import Button from '../../../../../components/shared/Button.vue'
 import { defaultLinkBranch, defaultLinkRepo } from './Links'
 import InputCopyToClipboard from '../../../../../organisms/InputCopyToClipboard.vue'
+import http from '../../../../../http'
 
 export default defineComponent({
   components: {
@@ -323,14 +324,13 @@ export default defineComponent({
     recommendedLinkBranch() {
       return defaultLinkBranch(this.gitRemoteURL)
     },
-    webhookTrigger() {
-      return (
-        window.location.protocol +
-        '//' +
-        window.location.host +
-        '/v3/remotes/webhook/sync-codebase/' +
-        this.data.codebase.id
-      )
+    webhookTrigger(): string {
+      if (!window.location || !this?.data?.codebase?.id) {
+        return ''
+      }
+      const base = http.url('/v3/remotes/webhook/sync-codebase/' + this.data.codebase.id)
+      // using the current browser location as the base, used if url() returns a relative url
+      return new URL(base, new URL(window.location.href)).href
     },
   },
 })


### PR DESCRIPTION
<p>web/Git: properly build webhook url</p><p>Support for <a target="_blank" rel="noopener noreferrer nofollow" href="http://localhost">localhost</a>, Cloud, and self-hosted.</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/0f5ad7eb-08b2-4c7c-936a-e12994234b9d).

Update this PR by making changes through Sturdy.
