### PR TITLE
api: always create an organisation for new cloud user

### DIFF
--- a/api/pkg/organization/graphql/resolver.go
+++ b/api/pkg/organization/graphql/resolver.go
@@ -152,7 +152,12 @@ func (r *organizationRootResolver) Organization(ctx context.Context, args resolv
 }
 
 func (r *organizationRootResolver) CreateOrganization(ctx context.Context, args resolvers.CreateOrganizationArgs) (resolvers.OrganizationResolver, error) {
-	org, err := r.service.Create(ctx, args.Input.Name)
+	userID, err := auth.UserID(ctx)
+	if err != nil {
+		return nil, gqlerrors.Error(err)
+	}
+
+	org, err := r.service.Create(ctx, userID, args.Input.Name)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}

--- a/api/pkg/organization/service/service.go
+++ b/api/pkg/organization/service/service.go
@@ -9,7 +9,6 @@ import (
 
 	"getsturdy.com/api/pkg/analytics"
 	service_analytics "getsturdy.com/api/pkg/analytics/service"
-	"getsturdy.com/api/pkg/auth"
 	"getsturdy.com/api/pkg/events/v2"
 	"getsturdy.com/api/pkg/organization"
 	db_organization "getsturdy.com/api/pkg/organization/db"
@@ -87,12 +86,7 @@ func (svc *Service) GetMember(ctx context.Context, organizationID string, userID
 	return member, nil
 }
 
-func (svc *Service) Create(ctx context.Context, name string) (*organization.Organization, error) {
-	userID, err := auth.UserID(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func (svc *Service) Create(ctx context.Context, userID users.ID, name string) (*organization.Organization, error) {
 	org := organization.Organization{
 		ID:        uuid.NewString(),
 		ShortID:   organization.ShortOrganizationID(shortid.New()),

--- a/api/pkg/users/enterprise/selfhosted/service/service.go
+++ b/api/pkg/users/enterprise/selfhosted/service/service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	service_installations "getsturdy.com/api/pkg/installations/service"
-	service_organization "getsturdy.com/api/pkg/organization/service"
 	"getsturdy.com/api/pkg/users"
 	service_oss_selfhosted "getsturdy.com/api/pkg/users/oss/selfhosted/service"
 	"getsturdy.com/api/pkg/users/service"
@@ -16,18 +15,15 @@ const maxUsersWithoutLicense = 10
 type Service struct {
 	*service_oss_selfhosted.Service
 
-	organizationService *service_organization.Service
 	installationService *service_installations.Service
 }
 
 func New(
 	userService *service_oss_selfhosted.Service,
-	organizationService *service_organization.Service,
 	installationService *service_installations.Service,
 ) *Service {
 	return &Service{
 		Service:             userService,
-		organizationService: organizationService,
 		installationService: installationService,
 	}
 }


### PR DESCRIPTION
<p>api: always create an organisation for new cloud user</p><p>now when we know that user’s name is always set (derived from the email), we can safely create the default org without asking</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/fef58ca8-89c3-41c7-837b-717281b01934).

Update this PR by making changes through Sturdy.
