### PR TITLE
api/vcs: cleanup unused libgit2 methods after moving to go-git

### DIFF
--- a/api/pkg/github/enterprise/service/pull_request.go
+++ b/api/pkg/github/enterprise/service/pull_request.go
@@ -247,7 +247,7 @@ func (svc *Service) CreateOrUpdatePullRequest(ctx context.Context, user *users.U
 	// This is done _without_ force, to not screw anything up if we're in the wrong.
 	if err := vcs.HaveTrackedBranch(svc.executorProvider, ws.CodebaseID, ghRepo.TrackedBranch); err != nil {
 		logger.Info("pushing sturdytrunk to github")
-		userVisibleError, pushTrunkErr := vcs.PushBranchToGithubSafely(logger, svc.executorProvider, ws.CodebaseID, "sturdytrunk", ghRepo.TrackedBranch, accessToken)
+		userVisibleError, pushTrunkErr := vcs.PushBranchToGithubSafely(svc.executorProvider, ws.CodebaseID, "sturdytrunk", ghRepo.TrackedBranch, accessToken)
 		if pushTrunkErr != nil {
 			logger.Error("failed to push trunk to github (github is source of truth)", zap.Error(pushTrunkErr))
 
@@ -264,7 +264,7 @@ func (svc *Service) CreateOrUpdatePullRequest(ctx context.Context, user *users.U
 		logger.Info("github have a default branch, not pushing sturdytrunk")
 	}
 
-	userVisibleError, pushErr := vcs.PushBranchToGithubWithForce(logger, svc.executorProvider, ws.CodebaseID, prBranch, remoteBranchName, *ghUser.AccessToken)
+	userVisibleError, pushErr := vcs.PushBranchToGithubWithForce(svc.executorProvider, ws.CodebaseID, prBranch, remoteBranchName, *ghUser.AccessToken)
 	if pushErr != nil {
 		logger.Error("failed to push to github (github is source of truth)", zap.Error(pushErr))
 

--- a/api/pkg/github/enterprise/service/service.go
+++ b/api/pkg/github/enterprise/service/service.go
@@ -201,12 +201,7 @@ func (svc *Service) Push(ctx context.Context, gitHubRepository *github.Repositor
 	// Push in a git executor context
 	var userVisibleError string
 	if err := svc.executorProvider.New().GitWrite(func(repo vcs.RepoGitWriter) error {
-		userVisibleError, err = github_vcs.PushTrackedToGitHub(
-			logger,
-			repo,
-			accessToken,
-			gitHubRepository.TrackedBranch,
-		)
+		userVisibleError, err = github_vcs.PushTrackedToGitHub(repo, accessToken, gitHubRepository.TrackedBranch)
 		if err != nil {
 			return err
 		}

--- a/api/pkg/remote/enterprise/service/service.go
+++ b/api/pkg/remote/enterprise/service/service.go
@@ -204,7 +204,7 @@ func (svc *EnterpriseService) Push(ctx context.Context, user *users.User, ws *wo
 	}
 
 	push := func(repo vcs.RepoGitWriter) error {
-		_, err := repo.PushRemoteUrlWithRefspecGogit(svc.logger, rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
+		_, err := repo.PushRemoteUrlWithRefspec(rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
 		switch {
 		case errors.Is(err, gogit.NoErrAlreadyUpToDate):
 			return nil
@@ -241,7 +241,7 @@ func (svc *EnterpriseService) PushTrunk(ctx context.Context, codebaseID codebase
 	}
 
 	push := func(repo vcs.RepoGitWriter) error {
-		_, err := repo.PushRemoteUrlWithRefspecGogit(svc.logger, rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
+		_, err := repo.PushRemoteUrlWithRefspec(rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
 		switch {
 		case errors.Is(err, gogit.NoErrAlreadyUpToDate):
 			return nil
@@ -278,7 +278,7 @@ func (svc *EnterpriseService) Pull(ctx context.Context, codebaseID codebases.ID)
 	}
 
 	pull := func(repo vcs.RepoGitWriter) error {
-		err := repo.FetchUrlRemoteWithCredsGogit(rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
+		err := repo.FetchUrlRemoteWithCreds(rem.URL, creds, []config.RefSpec{config.RefSpec(refspec)})
 		switch {
 		case errors.Is(err, gogit.NoErrAlreadyUpToDate):
 			return nil

--- a/api/vcs/git_remote_push_pull.go
+++ b/api/vcs/git_remote_push_pull.go
@@ -1,0 +1,122 @@
+package vcs
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+func (r *repository) PushRemoteUrlWithRefspec(remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error) {
+	defer getMeterFunc("PushRemoteUrlWithRefspec")()
+
+	gg, err := gogit.PlainOpen(r.path)
+	if err != nil {
+		return "", err
+	}
+
+	remote, err := gg.CreateRemoteAnonymous(&config.RemoteConfig{
+		Name: "anonymous",
+		URLs: []string{remoteUrl},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	err = remote.Push(&gogit.PushOptions{
+		RemoteName: "anonymous",
+		RefSpecs:   refspecs,
+		Auth:       creds,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+func (r *repository) PushNamedRemoteWithRefspec(remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error) {
+	defer getMeterFunc("PushNamedRemoteWithRefspec")()
+
+	gg, err := gogit.PlainOpen(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open gogit: %w", err)
+	}
+
+	remote, err := gg.Remote(remoteName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote: %w", err)
+	}
+
+	err = remote.Push(&gogit.PushOptions{
+		RemoteName: remoteName,
+		RefSpecs:   refspecs,
+		Auth:       creds,
+	})
+	if err != nil && strings.Contains(err.Error(), "protected branch hook declined") {
+		return fmt.Sprintf("GitHub rejected the push as the branch is protected by branch protection rules."), fmt.Errorf("failed to push to github: stopped by branch protection rules")
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to push: %w", err)
+	}
+	return "", nil
+}
+
+func (r *repository) FetchNamedRemoteWithCreds(remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) error {
+	defer getMeterFunc("FetchNamedRemoteWithCreds")()
+
+	gg, err := gogit.PlainOpen(r.path)
+	if err != nil {
+		return fmt.Errorf("failed to open gogit: %w", err)
+	}
+
+	remote, err := gg.Remote(remoteName)
+	if err != nil {
+		return fmt.Errorf("failed to get remote: %w", err)
+	}
+
+	err = remote.Fetch(&gogit.FetchOptions{
+		RefSpecs: refspecs,
+		Auth:     creds,
+		Progress: os.Stderr,
+		Depth:    100,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fetch: %w", err)
+	}
+
+	return nil
+}
+
+func (r *repository) FetchUrlRemoteWithCreds(remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) error {
+	defer getMeterFunc("FetchUrlRemoteWithCreds")()
+
+	gg, err := gogit.PlainOpen(r.path)
+	if err != nil {
+		return err
+	}
+
+	remote, err := gg.CreateRemoteAnonymous(&config.RemoteConfig{
+		Name: "anonymous",
+		URLs: []string{remoteUrl},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = remote.Fetch(&gogit.FetchOptions{
+		RefSpecs: refspecs,
+		Auth:     creds,
+		Progress: os.Stderr,
+		Depth:    100,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/vcs/repository.go
+++ b/api/vcs/repository.go
@@ -63,14 +63,12 @@ type RepoGitWriter interface {
 	CleanStaged() error
 	Push(logger *zap.Logger, branchName string) error
 	ForcePush(logger *zap.Logger, branchName string) error
-	PushNamedRemoteWithRefspecGogit(logger *zap.Logger, remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error)
-	PushRemoteUrlWithRefspec(logger *zap.Logger, remoteUrl string, creds git.CredentialsCallback, refspecs []string) (userError string, err error)
-	PushRemoteUrlWithRefspecGogit(logger *zap.Logger, remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error)
-
-	FetchNamedRemoteWithCredsGogit(remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) error
-	FetchUrlRemoteWithCreds(remoteUrl string, creds git.CredentialsCallback, refspecs []string) error
-	FetchUrlRemoteWithCredsGogit(remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) error
 	FetchBranch(branches ...string) error
+
+	PushNamedRemoteWithRefspec(remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error)
+	PushRemoteUrlWithRefspec(remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) (userError string, err error)
+	FetchNamedRemoteWithCreds(remoteName string, creds transport.AuthMethod, refspecs []config.RefSpec) error
+	FetchUrlRemoteWithCreds(remoteUrl string, creds transport.AuthMethod, refspecs []config.RefSpec) error
 
 	SetDefaultBranch(targetBranch string) error
 	CreateAndSetDefaultBranch(headBranchName string) error


### PR DESCRIPTION
<p>api/vcs: cleanup unused libgit2 methods after moving to go-git</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/8dda4d0a-9fe5-427b-9b07-064e9e05f345).

Update this PR by making changes through Sturdy.
