### PR TITLE
api/github/webhook: do not update global logger

### DIFF
--- a/api/pkg/github/enterprise/routes/webhook.go
+++ b/api/pkg/github/enterprise/routes/webhook.go
@@ -28,7 +28,7 @@ func Webhook(logger *zap.Logger, queue *workers_github.WebhooksQueue) func(c *gi
 			return
 		}
 
-		logger = logger.With(
+		logger := logger.With(
 			zap.String("X-GitHub-Delivery", c.Request.Header.Get("X-GitHub-Delivery")),
 			zap.String("X-GitHub-Event", c.Request.Header.Get("X-GitHub-Event")),
 			zap.String("X-GitHub-Hook-Id", c.Request.Header.Get("X-GitHub-Hook-Id")),


### PR DESCRIPTION
<p>api/github/webhook: do not update global logger</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/807479be-c838-4ce1-b912-442de914fd3f).

Update this PR by making changes through Sturdy.
