### PR TITLE
web/stackedMenu: make codebase left padding more than workspace’s

### DIFF
--- a/web/src/components/menu/StackedMenu.vue
+++ b/web/src/components/menu/StackedMenu.vue
@@ -57,7 +57,7 @@
                 ? 'bg-warmgray-50  hover:text-gray-900'
                 : 'hover:bg-warmgray-100  hover:text-gray-900',
 
-              'flex items-center pl-3 pr-1 py-2 text-sm font-semibold rounded-md mx-1 justify-between transition whitespace-nowrap space-x-2 h-10 cursor-pointer text-gray-700 my-0.5',
+              'flex items-center pl-2 pr-1 py-2 text-sm font-semibold rounded-md mx-1 justify-between transition whitespace-nowrap space-x-2 h-10 cursor-pointer text-gray-700 my-0.5',
             ]"
           >
             <span class="flex-1 overflow-hidden text-ellipsis flex-shrink-0">
@@ -126,7 +126,7 @@
                     id: workspace.id,
                   },
                 }"
-                class="whitespace-nowrap text-gray-500 text-sm font-medium py-2 pl-2 pr-2 inline-flex items-center relative rounded-md my-0.5 mx-1 group"
+                class="whitespace-nowrap text-gray-500 text-sm font-medium py-2 pl-3 pr-2 inline-flex items-center relative rounded-md my-0.5 mx-1 group"
                 :class="[
                   workspace.isCurrent
                     ? 'bg-warmgray-50 hover:text-gray-900'


### PR DESCRIPTION
<p>web/stackedMenu: make codebase left padding more than workspace’s</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/85d9292c-99d5-429d-98cf-8c2e80903a73).

Update this PR by making changes through Sturdy.
