### PR TITLE
api/ci: implement triggerWorkspace

### DIFF
--- a/api/pkg/auth/service/service.go
+++ b/api/pkg/auth/service/service.go
@@ -135,6 +135,10 @@ func (s *Service) hasAccess(ctx context.Context, at accessType, obj any) error {
 		}
 	case auth.SubjectCI:
 		switch object := obj.(type) {
+		case workspaces.Workspace:
+			return s.canCIAccessWorkspace(ctx, subject.ID, &object)
+		case *workspaces.Workspace:
+			return s.canCIAccessWorkspace(ctx, subject.ID, object)
 		case changes.Change:
 			return s.canCIAccessChange(ctx, subject.ID, &object)
 		case *changes.Change:
@@ -190,6 +194,13 @@ func (s *Service) hasAccess(ctx context.Context, at accessType, obj any) error {
 	default:
 		return fmt.Errorf("unsupported subject type '%s': %w", subject.Type, auth.ErrForbidden)
 	}
+}
+
+func (s *Service) canCIAccessWorkspace(ctx context.Context, workspaceID string, workspace *workspaces.Workspace) error {
+	if workspaceID != workspace.ID {
+		return fmt.Errorf("ci doesn't have access to the workspace: %w", auth.ErrForbidden)
+	}
+	return nil
 }
 
 func (s *Service) canCIAccessChange(ctx context.Context, changeID string, change *changes.Change) error {

--- a/api/pkg/ci/ci.go
+++ b/api/pkg/ci/ci.go
@@ -9,9 +9,9 @@ import (
 // Commit is the link between a commit in the trunk repo, and a commit in the "fake" ci repository that is being
 // used to trigger the ci service.
 type Commit struct {
-	ID             string       `db:"id"`
-	CodebaseID     codebases.ID `db:"codebase_id"`
-	CiRepoCommitID string       `db:"ci_repo_commit_id"`
-	TrunkCommitID  string       `db:"trunk_commit_id"`
-	CreatedAt      time.Time    `db:"created_at"`
+	ID              string       `db:"id"`
+	CodebaseID      codebases.ID `db:"codebase_id"`
+	CiRepoCommitSHA string       `db:"ci_repo_commit_id"`
+	TrunkCommitSHA  string       `db:"trunk_commit_id"`
+	CreatedAt       time.Time    `db:"created_at"`
 }

--- a/api/pkg/ci/service/download.bash
+++ b/api/pkg/ci/service/download.bash
@@ -5,52 +5,87 @@ set -euo pipefail
 echoerr() { echo "$@" 1>&2; }
 
 function change_id() {
-  cat sturdy.json | jq --raw-output '.change_id'
+	cat sturdy.json | jq --raw-output '.change_id'
 }
 
-function get_url() {
-  local id
-  local res
+function workspace_id() {
+	cat sturdy.json | jq --raw-output '.workspace_id'
+}
 
-  id=$1
+function get_workspace_url() {
+	local id
+	local res
 
-  echoerr "[Sturdy] Downloading change ${id}"
+	id=$1
 
-  res=$(
-    curl 'https://__PUBLIC_API__HOSTNAME__/graphql' \
-      --silent --show-error --fail \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json' \
-      -H 'Authorization: bearer __JWT__' \
-      --data-binary "{\"query\":\"query { change(id: \\\"${id}\\\") { id title downloadTarGz { url } } }\"}"
-  )
+	echoerr "[Sturdy] Downloading workspace ${id}"
 
-  echo "$res" | jq --raw-output '.data.change.downloadTarGz.url'
+	res=$(
+		curl 'https://__PUBLIC_API__HOSTNAME__/graphql' \
+			--silent --show-error --fail \
+			-H 'Content-Type: application/json' \
+			-H 'Accept: application/json' \
+			-H 'Authorization: bearer __JWT__' \
+			--data-binary "{\"query\":\"query { workspace(id: \\\"${id}\\\") { id downloadTarGz { url } } }\"}"
+	)
+
+	echo "$res" | jq --raw-output '.data.workspace.downloadTarGz.url'
+}
+
+function get_change_url() {
+	local id
+	local res
+
+	id=$1
+
+	echoerr "[Sturdy] Downloading change ${id}"
+
+	res=$(
+		curl 'https://__PUBLIC_API__HOSTNAME__/graphql' \
+			--silent --show-error --fail \
+			-H 'Content-Type: application/json' \
+			-H 'Accept: application/json' \
+			-H 'Authorization: bearer __JWT__' \
+			--data-binary "{\"query\":\"query { change(id: \\\"${id}\\\") { id title downloadTarGz { url } } }\"}"
+	)
+
+	echo "$res" | jq --raw-output '.data.change.downloadTarGz.url'
 }
 
 function download() {
-  curl $1 --silent > archive.tar.gz
+	curl $1 --silent >archive.tar.gz
 }
 
 function extract() {
-  echoerr "[Sturdy] Extracting..."
+	echoerr "[Sturdy] Extracting..."
 
-  tar -xzf archive.tar.gz -C tmp_output
+	tar -xzf archive.tar.gz -C tmp_output
 
-  echoerr "[Sturdy] Contents is now available in ./tmp_output"
+	echoerr "[Sturdy] Contents is now available in ./tmp_output"
 }
 
 function pre_cleanup() {
-  echo "[Sturdy] found existing tmp_output, cleaning it up"
-  rm -rf tmp_output
+	echo "[Sturdy] found existing tmp_output, cleaning it up"
+	rm -rf tmp_output
 }
 
 function prepare() {
-  [ -d "tmp_output" ] && pre_cleanup
+	[ -d "tmp_output" ] && pre_cleanup
 
-  mkdir tmp_output 2 /dev/null &>1 || true
+	mkdir tmp_output 2 /dev/null &>1 || true
 }
 
 prepare
-download $(get_url $(change_id))
-extract
+
+CHANGE_ID="$(change_id)"
+WORKSPACE_ID="$(workspace_id)"
+if [ -n "${WORKSPACE_ID}" ]; then
+    download "$(get_workspace_url "$WORKSPACE_ID")"
+    extract
+else if [ -n "${CHANGE_ID}" ]; then
+    download "$(get_change_url "$CHANGE_ID")"
+    extract
+else 
+    echoerr "[Sturdy] No workspace or change id found, exiting"
+    exit 1
+fi

--- a/api/pkg/ci/workers/runner.go
+++ b/api/pkg/ci/workers/runner.go
@@ -82,7 +82,7 @@ func (r *BuildQueue) trigger(ctx context.Context, ch *changes.Change) error {
 		zap.Stringer("codebase_id", ch.CodebaseID),
 	)
 
-	if _, err := r.ciService.Trigger(ctx, ch); err != nil {
+	if _, err := r.ciService.TriggerChange(ctx, ch); err != nil {
 		return fmt.Errorf("failed to trigger change: %w", err)
 	}
 

--- a/api/pkg/github/enterprise/webhooks/status.go
+++ b/api/pkg/github/enterprise/webhooks/status.go
@@ -47,7 +47,7 @@ func (svc *Service) HandleStatusEvent(ctx context.Context, event *StatusEvent) e
 
 	status := &statuses.Status{
 		ID:          uuid.New().String(),
-		CommitID:    event.GetCommit().GetSHA(),
+		CommitSHA:    event.GetCommit().GetSHA(),
 		CodebaseID:  repo.CodebaseID,
 		Type:        getStatusType(event),
 		Title:       event.GetContext(),

--- a/api/pkg/github/enterprise/webhooks/workflow.go
+++ b/api/pkg/github/enterprise/webhooks/workflow.go
@@ -92,7 +92,7 @@ func (svc *Service) HandleWorkflowJobEvent(ctx context.Context, event *WorkflowJ
 
 	status := &statuses.Status{
 		ID:         uuid.New().String(),
-		CommitID:   job.GetHeadSHA(),
+		CommitSHA:  job.GetHeadSHA(),
 		CodebaseID: repo.CodebaseID,
 		Type:       jobType,
 		Title:      job.GetName(),

--- a/api/pkg/integrations/graphql/root.go
+++ b/api/pkg/integrations/graphql/root.go
@@ -64,7 +64,7 @@ func (r *rootResolver) TriggerInstantIntegration(ctx context.Context, args resol
 		}
 	}
 
-	ss, err := r.svc.Trigger(ctx, ch, triggerOptions...)
+	ss, err := r.svc.TriggerChange(ctx, ch, triggerOptions...)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}

--- a/api/pkg/integrations/providers/buildkite/enterprise/routes/webhook.go
+++ b/api/pkg/integrations/providers/buildkite/enterprise/routes/webhook.go
@@ -157,8 +157,7 @@ func WebhookHandler(
 			}
 		}
 
-		// Lookup trunk commit id
-		trunkCommitID, err := ciService.GetTrunkCommitID(c.Request.Context(), serviceToken.CodebaseID, *payload.Build.Commit)
+		trunkCommitSHA, err := ciService.GetTrunkCommitSHA(c.Request.Context(), serviceToken.CodebaseID, *payload.Build.Commit)
 		if errors.Is(err, sql.ErrNoRows) {
 			c.AbortWithError(http.StatusBadRequest, fmt.Errorf("unknown commit: %s", *payload.Build.Commit))
 			return
@@ -178,7 +177,7 @@ func WebhookHandler(
 		webURL := payload.WebURL()
 		if err := statusesService.Set(c, &statuses.Status{
 			ID:         uuid.NewString(),
-			CommitID:   trunkCommitID,
+			CommitSHA:  trunkCommitSHA,
 			CodebaseID: serviceToken.CodebaseID,
 			Type:       statusType,
 			Title:      payload.Title(),

--- a/api/pkg/snapshots/snapshot.go
+++ b/api/pkg/snapshots/snapshot.go
@@ -51,4 +51,5 @@ const (
 	ActionWorkspaceExtract          Action = "workspace_extract"
 	ActionChangeReverted            Action = "change_reverted"
 	ActionSuggestionApply           Action = "suggestion_apply"
+	ActionCITrigger                 Action = "ci_trigger"
 )

--- a/api/pkg/statuses/enterprise/graphql/resolver.go
+++ b/api/pkg/statuses/enterprise/graphql/resolver.go
@@ -69,7 +69,7 @@ func (r *RootResolver) UpdatedGitHubPullRequestStatuses(ctx context.Context, arg
 
 	c := make(chan resolvers.StatusResolver, 100)
 	r.eventsReader.OnStatusUpdated(ctx, eventsv2.SubscribeUser(userID), func(ctx context.Context, status *statuses.Status) error {
-		if status.CommitID != *pr.HeadSHA {
+		if status.CommitSHA != *pr.HeadSHA {
 			return nil
 		}
 

--- a/api/pkg/statuses/graphql/resolver.go
+++ b/api/pkg/statuses/graphql/resolver.go
@@ -98,7 +98,7 @@ func (r *RootResolver) UpdateStatus(ctx context.Context, args resolvers.UpdateSt
 
 	status := &statuses.Status{
 		ID:          uuid.NewString(),
-		CommitID:    *ch.CommitID,
+		CommitSHA:    *ch.CommitID,
 		CodebaseID:  ch.CodebaseID,
 		Type:        tp,
 		Title:       args.Input.Title,
@@ -155,7 +155,7 @@ func (r *resolver) Timestamp() int32 {
 func (r *resolver) Change(ctx context.Context) (resolvers.ChangeResolver, error) {
 	change, err := r.root.changeRootResolver.Change(ctx, resolvers.ChangeArgs{
 		CodebaseID: (*graphql.ID)(&r.status.CodebaseID),
-		CommitID:   (*graphql.ID)(&r.status.CommitID),
+		CommitID:   (*graphql.ID)(&r.status.CommitSHA),
 	})
 	switch {
 	case err == nil:
@@ -168,7 +168,7 @@ func (r *resolver) Change(ctx context.Context) (resolvers.ChangeResolver, error)
 }
 
 func (r *resolver) GitHubPullRequest(ctx context.Context) (resolvers.GitHubPullRequestResolver, error) {
-	if pullRequest, err := r.root.gitHubPrResovler.InternalByCodebaseIDAndHeadSHA(ctx, r.status.CodebaseID, r.status.CommitID); errors.Is(err, gqlerrors.ErrNotFound) {
+	if pullRequest, err := r.root.gitHubPrResovler.InternalByCodebaseIDAndHeadSHA(ctx, r.status.CodebaseID, r.status.CommitSHA); errors.Is(err, gqlerrors.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/api/pkg/statuses/graphql/updatedChangesStatuses.go
+++ b/api/pkg/statuses/graphql/updatedChangesStatuses.go
@@ -48,7 +48,7 @@ func (r *RootResolver) UpdatedChangesStatuses(ctx context.Context, args resolver
 	didErrorOut := false
 
 	r.eventsSubscriber.OnStatusUpdated(ctx, eventsv2.SubscribeUser(userID), func(ctx context.Context, status *statuses.Status) error {
-		if !watchCommit[status.CommitID] {
+		if !watchCommit[status.CommitSHA] {
 			return nil
 		}
 

--- a/api/pkg/statuses/status.go
+++ b/api/pkg/statuses/status.go
@@ -23,7 +23,7 @@ var ValidType = map[Type]bool{
 
 type Status struct {
 	ID          string       `db:"id" json:"id"`
-	CommitID    string       `db:"commit_id" json:"commit_id"`
+	CommitSHA   string       `db:"commit_id" json:"commit_id"`
 	CodebaseID  codebases.ID `db:"codebase_id" json:"codebase_id"`
 	Type        Type         `db:"type" json:"type"`
 	Title       string       `db:"title" json:"title"`


### PR DESCRIPTION
<p>api/ci: implement triggerWorkspace</p><p>this will make it possible to trigger ci on a workspace - which actually runs ci on the workspace’s LatestSnapshot.CommitSHA</p><p>snapshot entity is not exposed directly to be in pair with the api where we do not expose snapshots</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/8d0a3407-f74f-4ca2-b001-0618ae870bca).

Update this PR by making changes through Sturdy.
