### PR TITLE
api/pkg/ci: add null check to download script

### DIFF
--- a/api/pkg/ci/service/download.bash
+++ b/api/pkg/ci/service/download.bash
@@ -80,10 +80,10 @@ prepare
 CHANGE_ID="$(change_id)"
 WORKSPACE_ID="$(workspace_id)"
 
-if [ -n "${WORKSPACE_ID}" ]; then
+if [ -n "${WORKSPACE_ID}" ] && [ "${WORKSPACE_ID}" != "null" ]; then
     download "$(get_workspace_url "$WORKSPACE_ID")"
     extract
-elif [ -n "${CHANGE_ID}" ]; then
+elif [ -n "${CHANGE_ID}" ] && [ "${CHANGE_ID}" != "null" ]; then
     download "$(get_change_url "$CHANGE_ID")"
     extract
 else 


### PR DESCRIPTION
<p>api/pkg/ci: add null check to download script</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/eeccc0ce-ef47-4d93-ae82-bb274914ca7b).

Update this PR by making changes through Sturdy.
