### PR TITLE
web/connectNewDirectory: handle view already exists

### DIFF
--- a/web/src/organisms/electron/ConnectNewDirectory.vue
+++ b/web/src/organisms/electron/ConnectNewDirectory.vue
@@ -133,6 +133,13 @@ export default defineComponent({
               style: 'error',
             })
             return
+          } else if (e.message.includes('view already exists')) {
+            this.emitter.emit('notification', {
+              title: 'Directory is already connected',
+              message: 'You can connect directory twice. Plese select another directory.',
+              style: 'error',
+            })
+            return
           } else if (e.message.includes('Cancelled')) {
             await this.archiveWorkspace(workspace.id)
             return


### PR DESCRIPTION
<p>web/connectNewDirectory: handle view already exists</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/b0b2c338-8251-401a-a4ee-96dbe74168ae).

Update this PR by making changes through Sturdy.
