### PR TITLE
oneliner: disable buffering in logging

### DIFF
--- a/oneliner/etc/s6-overlay/s6-rc.d/api-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/api-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[api] /'
+sed --unbuffered 's/^/[api] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/postgresql-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/postgresql-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[postgresql] /'
+sed --unbuffered 's/^/[postgresql] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/reproxy-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/reproxy-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[reproxy] /'
+sed --unbuffered 's/^/[reproxy] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/rudolfs-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/rudolfs-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[rudolfs] /'
+sed --unbuffered 's/^/[rudolfs] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/ssh-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/ssh-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[ssh] /'
+sed --unbuffered 's/^/[ssh] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/sslmux-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/sslmux-log/run
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[sslmux] /'
+sed --unbuffered 's/^/[sslmux] /'

--- a/oneliner/etc/s6-overlay/s6-rc.d/sslmux80-log/run
+++ b/oneliner/etc/s6-overlay/s6-rc.d/sslmux80-log/run
@@ -2,5 +2,4 @@
 
 set -euo pipefail
 
-sed 's/^/[sslmux80] /'
-calc
+sed --unbuffered  's/^/[sslmux80] /'


### PR DESCRIPTION
<p>oneliner: disable buffering in logging</p><p>This makes the first time setup more responsive</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/dd2be018-b5ef-4ed9-bfe1-4bea6fe542b4).

Update this PR by making changes through Sturdy.
