### PR TITLE
app: register scheme handlers properly on Linux

### DIFF
--- a/app/electron-builder.yaml
+++ b/app/electron-builder.yaml
@@ -1,5 +1,10 @@
 productName: Sturdy
 appId: com.getsturdy.sturdy
+copyright: "Copyright © 2022 Sturdy Sweden AB"
+
+protocols:
+  - name: "sturdy"
+    schemes: ["sturdy"]
 
 generateUpdatesFilesForAllChannels: true
 detectUpdateChannel: true

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.5.22-alpha.1",
+  "version": "0.5.23-alpha.10",
   "name": "SturdyDev",
   "author": "Sturdy Team <support@getsturdy.com>",
   "description": "Real-Time Version Control",
@@ -30,7 +30,7 @@
     "autoprefixer": "^10.4.2",
     "cross-env": "^7.0.3",
     "cssnano": "^5.0.17",
-    "electron": "^18.0.0",
+    "electron": "^19.0.0-alpha.1",
     "electron-builder": "^23.0.2",
     "electron-notarize": "^1.1.1",
     "eslint": "^7.32.0",

--- a/app/src/AppImageHandler.ts
+++ b/app/src/AppImageHandler.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs'
+import { app } from 'electron'
+import * as child_process from 'child_process'
+
+export const CreateAppImageDesktopFile = (path: string) => {
+  console.log('Creating .desktop file')
+
+  const contents = `[Desktop Entry]
+Type=Application
+Name=Sturdy
+Exec=${path} %u
+StartupNotify=false
+MimeType=text/html;x-scheme-handler/sturdy;`
+
+  fs.writeFileSync(`${app.getPath('home')}/.local/share/applications/sturdy.desktop`, contents)
+
+  // update desktop database
+  child_process.exec('update-desktop-database ~/.local/share/applications')
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -55,10 +55,10 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@electron/get@^1.13.0":
-  version "1.13.1"
-  resolved "https://registry.npmjs.org/@electron/get/-/get-1.13.1.tgz"
-  integrity sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==
+"@electron/get@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
+  integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
   dependencies:
     debug "^4.1.1"
     env-paths "^2.2.0"
@@ -1856,12 +1856,12 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-18.0.0.tgz#c43fda5b8470a69313cdd79ba370ee6e42cda5b8"
-  integrity sha512-olAmqc+pNCDM9/nvYnZxhbAwQlMF01lDCesTKJjwItu2DaWZZm959OFTD+1mc/Q/YHDq9eqyD7MjqxjKuoWgWQ==
+electron@^19.0.0-alpha.1:
+  version "19.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.0-alpha.1.tgz#cffcc5966aebe4240971596df579a6ec492b4477"
+  integrity sha512-lBcTEZ1SgU95/wGDnOSwklTkaymGDhHF7Zg6L7dKntWOAOe2Be5RQ4TKSyZKAinKYcXCQ8+zZlCH6SKYndCjgA==
   dependencies:
-    "@electron/get" "^1.13.0"
+    "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
<p>app: register scheme handlers properly on Linux</p><p>If the app is running as a AppImage, create a .desktop file in the users $HOME.</p><p>For deb and rpm packages, electron-builder does everything we need.</p><p>Updated to Electron 19 as Electron 18 has a bug and does not start under linux/aarch64</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/6ee5710d-d505-4472-b828-a36f84fb6e6a).

Update this PR by making changes through Sturdy.
