### PR TITLE
vcs/executor: reset tmp view when reusing

### DIFF
--- a/api/pkg/downloads/enterprise/cloud/service/service.go
+++ b/api/pkg/downloads/enterprise/cloud/service/service.go
@@ -75,11 +75,18 @@ func (svc *Service) CreateArchive(ctx context.Context, allower *unidiff.Allower,
 
 	archiveFilePath := fmt.Sprintf("%s/%s%s", codebaseID, commitID, archiveFileExt)
 	if err := svc.executorProvider.New().Write(func(repo vcs.RepoWriter) error {
-		if err := repo.CreateNewBranchAt("archive", commitID); err != nil {
-			return fmt.Errorf("failed to create archive branch: %w", err)
+		branchName, err := repo.HeadBranch()
+		if err != nil {
+			return fmt.Errorf("failed to get branch name: %w", err)
 		}
-		if err := repo.CheckoutBranchWithForce("archive"); err != nil {
-			return fmt.Errorf("failed to checkout archive: %w", err)
+		if branchName != "archive" {
+
+			if err := repo.CreateNewBranchAt("archive", commitID); err != nil {
+				return fmt.Errorf("failed to create archive branch: %w", err)
+			}
+			if err := repo.CheckoutBranchWithForce("archive"); err != nil {
+				return fmt.Errorf("failed to checkout archive: %w", err)
+			}
 		}
 		return repo.LargeFilesPull()
 	}).Read(func(repo vcs.RepoReader) error {

--- a/api/vcs/executor/executor.go
+++ b/api/vcs/executor/executor.go
@@ -342,6 +342,17 @@ func (e *executor) ExecTemporaryView(codebaseID codebases.ID, actionName string)
 			} else if err != nil {
 				return fmt.Errorf("failed to stat view: %w", err)
 			} else {
+				// checkout sturdy trunk as if it is a new view
+				repo, err := repoProvider.ViewRepo(codebaseID, viewID)
+				if err != nil {
+					return fmt.Errorf("failed to open view repo: %w", err)
+				}
+				if err := repo.FetchBranch("sturdytrunk"); err != nil {
+					return fmt.Errorf("failed to fetch branch: %w", err)
+				}
+				if err := repo.CheckoutBranchWithForce("sturdytrunk"); err != nil {
+					return fmt.Errorf("failed to checkout branch: %w", err)
+				}
 				return nil
 			}
 		},


### PR DESCRIPTION
<p>vcs/executor: reset tmp view when reusing</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/d8b01552-2641-4407-8fe9-907938cf4496).

Update this PR by making changes through Sturdy.
