### PR TITLE
Revert api/github: set user context when processing webhooks

### DIFF
--- a/api/pkg/auth/subject.go
+++ b/api/pkg/auth/subject.go
@@ -48,10 +48,6 @@ type subjectKeyType struct{}
 
 var subjectKey = subjectKeyType{}
 
-func NewUser(ctx context.Context, id users.ID) context.Context {
-	return NewContext(ctx, &Subject{ID: string(id), Type: SubjectUser})
-}
-
 func NewContext(ctx context.Context, s *Subject) context.Context {
 	return context.WithValue(ctx, subjectKey, s)
 }

--- a/api/pkg/github/enterprise/webhooks/service.go
+++ b/api/pkg/github/enterprise/webhooks/service.go
@@ -16,7 +16,6 @@ import (
 	service_activity "getsturdy.com/api/pkg/activity/service"
 	"getsturdy.com/api/pkg/analytics"
 	service_analytics "getsturdy.com/api/pkg/analytics/service"
-	"getsturdy.com/api/pkg/auth"
 	service_change "getsturdy.com/api/pkg/changes/service"
 	workers_ci "getsturdy.com/api/pkg/ci/workers"
 	"getsturdy.com/api/pkg/codebases"
@@ -219,7 +218,6 @@ func (svc *Service) importNewPullRequest(ctx context.Context, repo *github.Repos
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)
 	}
-	ctx = auth.NewUser(ctx, user.ID)
 
 	installation, err := svc.gitHubInstallationRepo.GetByInstallationID(repo.InstallationID)
 	if err != nil {
@@ -317,8 +315,6 @@ func (svc *Service) updateExistingPullRequest(
 	} else if err != nil {
 		return fmt.Errorf("failed to get workspace from db: %w", err)
 	}
-
-	ctx = auth.NewUser(ctx, ws.UserID)
 
 	// update ws
 	if pr.Importing {
@@ -574,7 +570,7 @@ func (svc *Service) HandleInstallationEvent(ctx context.Context, event *Installa
 		if event.GetAction() == "created" {
 			for _, r := range event.Repositories {
 
-				if err := svc.handleInstalledRepository(ctx, event.GetInstallation().GetID(), r); err != nil {
+				if err := svc.handleInstalledRepository(event.GetInstallation().GetID(), r); err != nil {
 					return err
 				}
 			}
@@ -594,7 +590,7 @@ func (svc *Service) HandleInstallationRepositoriesEvent(ctx context.Context, eve
 	_, err := svc.gitHubInstallationRepo.GetByInstallationID(event.GetInstallation().GetID())
 	// If the original InstallationEvent webhook was missed (otherwise user has to remove and re-add app)
 	if errors.Is(err, sql.ErrNoRows) {
-		installation := &github.Installation{
+		installation := github.Installation{
 			ID:                     uuid.NewString(),
 			InstallationID:         event.Installation.GetID(),
 			Owner:                  event.Installation.Account.GetLogin(), // "sturdy-dev" or "zegl", etc.
@@ -602,17 +598,15 @@ func (svc *Service) HandleInstallationRepositoriesEvent(ctx context.Context, eve
 			HasWorkflowsPermission: true,
 		}
 
-		if err := svc.gitHubInstallationRepo.Create(*installation); err != nil {
+		if err := svc.gitHubInstallationRepo.Create(installation); err != nil {
 			return err
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to get installation: %w", err)
 	}
 
 	if event.GetRepositorySelection() == "selected" || event.GetRepositorySelection() == "all" {
 		// Add new repos
 		for _, r := range event.RepositoriesAdded {
-			if err := svc.handleInstalledRepository(ctx, event.GetInstallation().GetID(), r); err != nil {
+			if err := svc.handleInstalledRepository(event.GetInstallation().GetID(), r); err != nil {
 				return err
 			}
 		}
@@ -650,7 +644,9 @@ func (svc *Service) HandleInstallationRepositoriesEvent(ctx context.Context, eve
 	return nil
 }
 
-func (svc *Service) handleInstalledRepository(ctx context.Context, installationID int64, ghRepo *api.Repository) error {
+func (svc *Service) handleInstalledRepository(installationID int64, ghRepo *api.Repository) error {
+	ctx := context.Background()
+
 	// CreateWithCommitAsParent a non-ready codebase (add the initiating user), and put the event on a queue
 	logger := svc.logger.With(zap.String("repo_name", ghRepo.GetName()), zap.Int64("installation_id", installationID))
 	logger.Info("handleInstalledRepository")

--- a/api/pkg/workspaces/service/service.go
+++ b/api/pkg/workspaces/service/service.go
@@ -441,7 +441,7 @@ func (s *WorkspaceService) Create(ctx context.Context, req CreateWorkspaceReques
 		}
 	}
 
-	s.analyticsService.Capture(ctx, "create workspace",
+	s.analyticsService.CaptureUser(ctx, ws.UserID, "create workspace",
 		analytics.CodebaseID(req.CodebaseID),
 		analytics.Property("id", ws.ID),
 		analytics.Property("at_existing_change", req.BaseChangeID != nil),


### PR DESCRIPTION
<p><strong>Revert api/github: set user context when processing webhooks</strong></p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/2da3e914-296f-484a-b70a-4c2d235c6ce9).

Update this PR by making changes through Sturdy.
