### PR TITLE
api/ctx: set user context manually where it’s not set by the middleware

### DIFF
--- a/api/pkg/auth/subject.go
+++ b/api/pkg/auth/subject.go
@@ -48,6 +48,13 @@ type subjectKeyType struct{}
 
 var subjectKey = subjectKeyType{}
 
+func NewUserContext(ctx context.Context, userID users.ID) context.Context {
+	return NewContext(ctx, &Subject{
+		ID:   string(userID),
+		Type: SubjectUser,
+	})
+}
+
 func NewContext(ctx context.Context, s *Subject) context.Context {
 	return context.WithValue(ctx, subjectKey, s)
 }

--- a/api/pkg/emails/transactional/sender.go
+++ b/api/pkg/emails/transactional/sender.go
@@ -506,42 +506,7 @@ func (e *Sender) Send(
 		return fmt.Errorf("failed to send email: %w", err)
 	}
 
-	e.analyticsService.Capture(ctx, "email_sent", analytics.DistinctID(u.ID.String()),
-		analytics.Property("template", string(template)),
-		analytics.Property("subject", subject),
-	)
-
-	return nil
-}
-
-func (e *Sender) SendToSomeone(
-	ctx context.Context,
-	invitingUser *users.User,
-	invitedUser *users.User,
-	subject string,
-	template templates.Template,
-	data any,
-) error {
-	content, err := templates.Render(template, data)
-	if err != nil {
-		return fmt.Errorf("failed to render email: %w", err)
-	}
-
-	e.logger.Info(
-		"sending email",
-		zap.Stringer("user_id", invitingUser.ID),
-		zap.String("template", string(template)),
-	)
-
-	if err := e.sender.Send(ctx, &emails.Email{
-		To:      invitedUser.Email,
-		Subject: subject,
-		Html:    content,
-	}); err != nil {
-		return fmt.Errorf("failed to send email: %w", err)
-	}
-
-	e.analyticsService.Capture(ctx, "email_sent", analytics.DistinctID(invitingUser.ID.String()),
+	e.analyticsService.CaptureUser(ctx, u.ID, "email_sent", analytics.DistinctID(u.ID.String()),
 		analytics.Property("template", string(template)),
 		analytics.Property("subject", subject),
 	)

--- a/api/pkg/github/enterprise/webhooks/service.go
+++ b/api/pkg/github/enterprise/webhooks/service.go
@@ -16,6 +16,7 @@ import (
 	service_activity "getsturdy.com/api/pkg/activity/service"
 	"getsturdy.com/api/pkg/analytics"
 	service_analytics "getsturdy.com/api/pkg/analytics/service"
+	"getsturdy.com/api/pkg/auth"
 	service_change "getsturdy.com/api/pkg/changes/service"
 	workers_ci "getsturdy.com/api/pkg/ci/workers"
 	"getsturdy.com/api/pkg/codebases"
@@ -315,6 +316,9 @@ func (svc *Service) updateExistingPullRequest(
 	} else if err != nil {
 		return fmt.Errorf("failed to get workspace from db: %w", err)
 	}
+
+	// make context user context to connect all events to the same user
+	ctx = auth.NewUserContext(ctx, ws.UserID)
 
 	// update ws
 	if pr.Importing {

--- a/api/pkg/users/enterprise/cloud/service/service.go
+++ b/api/pkg/users/enterprise/cloud/service/service.go
@@ -7,6 +7,7 @@ import (
 
 	"getsturdy.com/api/pkg/analytics"
 	service_analytics "getsturdy.com/api/pkg/analytics/service"
+	"getsturdy.com/api/pkg/auth"
 	"getsturdy.com/api/pkg/emails/transactional"
 	"getsturdy.com/api/pkg/jwt"
 	service_jwt "getsturdy.com/api/pkg/jwt/service"
@@ -94,6 +95,8 @@ func (s *Service) Create(ctx context.Context, name, email string) (*users.User, 
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
+	ctx = auth.NewUserContext(ctx, newUser.ID)
+
 	// create default org for the user
 	if _, err := s.organizationService.Create(ctx, newUser.ID, fmt.Sprintf("%s's project", newUser.Name)); err != nil {
 		return nil, fmt.Errorf("failed to create organization: %w", err)
@@ -149,6 +152,7 @@ func (s *Service) VerifyMagicLink(ctx context.Context, user *users.User, code st
 	if _, err := s.onetimeService.Resolve(ctx, user, code); err != nil {
 		return fmt.Errorf("failed to resolve magic link: %w", err)
 	}
+	ctx = auth.NewUserContext(ctx, user.ID)
 
 	if err := s.setEmailVerified(ctx, user); err != nil {
 		return fmt.Errorf("failed to set email verified: %w", err)


### PR DESCRIPTION
<p>api/ctx: set user context manually where it’s not set by the middleware</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/1e233736-cb63-463e-ba33-6e64f9a595c3).

Update this PR by making changes through Sturdy.
