### PR TITLE
web/workspace: merge github button tooltip to the left

### DIFF
--- a/web/src/organisms/WorkspaceMergeGitHubButton.vue
+++ b/web/src/organisms/WorkspaceMergeGitHubButton.vue
@@ -92,7 +92,6 @@
           :disabled="isMerging || creatingOrUpdatingPR"
           :show-tooltip="isMerging"
           :submitting-a-pull-request="isMerging"
-          :tooltip-right="true"
           :spinner="isMerging"
           @click="triggerMergePullRequest"
         >


### PR DESCRIPTION
<p>web/workspace: merge github button tooltip to the left</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/332c24c1-9134-4c6c-95fc-5b8614acac37).

Update this PR by making changes through Sturdy.
