### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/api/pkg/snapshots/vcs/snapshots_test.go
+++ b/api/pkg/snapshots/vcs/snapshots_test.go
@@ -116,7 +116,6 @@ func TestSnapshot(t *testing.T) {
 }
 
 func reposBasePath(t *testing.T) (string, provider.RepoProvider) {
-	reposBasePath, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	reposBasePath := t.TempDir()
 	return reposBasePath, provider.New(reposBasePath, "")
 }

--- a/api/pkg/unidiff/git_diff_test.go
+++ b/api/pkg/unidiff/git_diff_test.go
@@ -2,11 +2,12 @@ package unidiff
 
 import (
 	"fmt"
-	"getsturdy.com/api/vcs"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"getsturdy.com/api/vcs"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -55,12 +56,11 @@ func TestCurrentDiffs(t *testing.T) {
 
 	for idx, tc := range cases {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-			assert.NoError(t, err)
+			tmpBase := t.TempDir()
 
 			pathBase := tmpBase + "base"
 			repoPath := tmpBase + "client-a"
-			_, err = vcs.CreateBareRepoWithRootCommit(pathBase)
+			_, err := vcs.CreateBareRepoWithRootCommit(pathBase)
 			if err != nil {
 				panic(err)
 			}
@@ -93,12 +93,11 @@ func TestCurrentDiffs(t *testing.T) {
 }
 
 func TestCurrentDiff(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
-	_, err = vcs.CreateBareRepoWithRootCommit(pathBase)
+	_, err := vcs.CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}
@@ -169,12 +168,11 @@ func TestCurrentDiff(t *testing.T) {
 }
 
 func TestCurrentDiffWithNestedNewDirs(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
-	_, err = vcs.CreateBareRepoWithRootCommit(pathBase)
+	_, err := vcs.CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}
@@ -243,12 +241,11 @@ func TestCurrentDiffWithNestedNewDirs(t *testing.T) {
 }
 
 func TestCurrentDiffDeletedFile(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
-	_, err = vcs.CreateBareRepoWithRootCommit(pathBase)
+	_, err := vcs.CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}

--- a/api/pkg/unidiff/unidiff_test.go
+++ b/api/pkg/unidiff/unidiff_test.go
@@ -3,7 +3,6 @@ package unidiff
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -325,8 +324,7 @@ func TestFilterAndApply(t *testing.T) {
 	}
 	assert.Equal(t, expectedDiffs, diffs)
 
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 	repoProvider := provider.New(tmpBase, "")
 	codebaseID := codebases.ID(uuid.NewString())
 	trunkPath := repoProvider.TrunkPath(codebaseID)

--- a/api/pkg/view/vcs/vcs_test.go
+++ b/api/pkg/view/vcs/vcs_test.go
@@ -1,8 +1,6 @@
 package vcs_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"getsturdy.com/api/pkg/codebases"
@@ -56,7 +54,6 @@ func TestSetWorkspace(t *testing.T) {
 }
 
 func newRepoProvider(t *testing.T) provider.RepoProvider {
-	reposBasePath, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	reposBasePath := t.TempDir()
 	return provider.New(reposBasePath, "")
 }

--- a/api/vcs/executor/flock_inprocess_test.go
+++ b/api/vcs/executor/flock_inprocess_test.go
@@ -1,17 +1,13 @@
 package executor
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInProcess_RLockNonBlocksRLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	lock := New(filepath.Join(dir, ".lock"))
 
 	lockSecond := make(chan struct{})
@@ -34,8 +30,7 @@ func TestInProcess_RLockNonBlocksRLock(t *testing.T) {
 }
 
 func TestInProcess_UnlockUnblocksLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	lock := New(filepath.Join(dir, ".lock"))
 
 	lockSecond := make(chan struct{})
@@ -62,8 +57,7 @@ func TestInProcess_UnlockUnblocksLock(t *testing.T) {
 }
 
 func TestInProcess_LockBlocksLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	lock := New(filepath.Join(dir, ".lock"))
 	lockSecond := make(chan struct{})
 	secondLocked := make(chan struct{})
@@ -85,8 +79,7 @@ func TestInProcess_LockBlocksLock(t *testing.T) {
 }
 
 func TestInProcess_RLockBlocksLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	lock := New(filepath.Join(dir, ".lock"))
 
 	lockSecond := make(chan struct{})
@@ -108,8 +101,7 @@ func TestInProcess_RLockBlocksLock(t *testing.T) {
 	}
 }
 func TestInProcess_RUnlockUnblocksLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 
 	lock := New(filepath.Join(dir, ".lock"))
 
@@ -137,8 +129,7 @@ func TestInProcess_RUnlockUnblocksLock(t *testing.T) {
 }
 
 func TestInProcess_LockBlocksRLock(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	lock := New(filepath.Join(dir, ".lock"))
 	rlockSecond := make(chan struct{})
 	secondRLocked := make(chan struct{})

--- a/api/vcs/git_commit_test.go
+++ b/api/vcs/git_commit_test.go
@@ -1,16 +1,13 @@
 package vcs
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateCommitWithFiles(t *testing.T) {
-	repoPath, err := ioutil.TempDir(os.TempDir(), "sturdy")
-	assert.NoError(t, err)
+	repoPath := t.TempDir()
 
 	repo, err := CreateBareRepoWithRootCommit(repoPath)
 	assert.NoError(t, err)

--- a/api/vcs/git_file_test.go
+++ b/api/vcs/git_file_test.go
@@ -1,20 +1,20 @@
 package vcs
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileContentsAtCommit(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
-	_, err = CreateBareRepoWithRootCommit(pathBase)
+	_, err := CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}
@@ -45,12 +45,11 @@ func TestFileContentsAtCommit(t *testing.T) {
 }
 
 func TestDirectoryChildrenAtCommit(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
-	_, err = CreateBareRepoWithRootCommit(pathBase)
+	_, err := CreateBareRepoWithRootCommit(pathBase)
 	assert.NoError(t, err)
 	repoA, err := CloneRepo(pathBase, clientA)
 	assert.NoError(t, err)

--- a/api/vcs/git_patches_test.go
+++ b/api/vcs/git_patches_test.go
@@ -6,18 +6,16 @@ import (
 
 	"getsturdy.com/api/pkg/unidiff"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 )
 
 func TestCanApplyPatch(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := path.Join(tmpBase, "trunk")
 	pathCheckout := path.Join(tmpBase, "checkout")
-	_, err = CreateBareRepoWithRootCommit(pathBase)
+	_, err := CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}

--- a/api/vcs/git_test.go
+++ b/api/vcs/git_test.go
@@ -2,7 +2,6 @@ package vcs
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"go.uber.org/zap"
@@ -11,8 +10,7 @@ import (
 )
 
 func TestListBranches(t *testing.T) {
-	repoPath, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	repoPath := t.TempDir()
 
 	repo, err := CreateBareRepoWithRootCommit(repoPath)
 	if err != nil {
@@ -30,8 +28,7 @@ func TestListBranches(t *testing.T) {
 }
 
 func TestDiffFromBare(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
@@ -76,14 +73,13 @@ func TestDiffFromBare(t *testing.T) {
 }
 
 func TestHeadBranch(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
+	tmpBase := t.TempDir()
 
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
 
 	t.Log("Creating bare base repo at", pathBase)
-	_, err = CreateBareRepoWithRootCommit(pathBase)
+	_, err := CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}
@@ -110,9 +106,7 @@ func TestHeadBranch(t *testing.T) {
 }
 
 func TestPushPull(t *testing.T) {
-	tmpBase, err := ioutil.TempDir(os.TempDir(), "mash")
-	assert.NoError(t, err)
-
+	tmpBase := t.TempDir()
 	pathBase := tmpBase + "base"
 	clientA := tmpBase + "client-a"
 	clientB := tmpBase + "client-b"
@@ -121,7 +115,7 @@ func TestPushPull(t *testing.T) {
 
 	logger := zap.NewNop()
 
-	_, err = CreateBareRepoWithRootCommit(pathBase)
+	_, err := CreateBareRepoWithRootCommit(pathBase)
 	if err != nil {
 		panic(err)
 	}

--- a/client/cmd/sturdy/init_test.go
+++ b/client/cmd/sturdy/init_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestPathIsInGitRepo_IsOutside(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "sturdy")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	is, gitPath := pathIsInGitRepo(tmpDir)
 	assert.False(t, is)
 	assert.Empty(t, gitPath)
@@ -25,11 +24,10 @@ func TestPathIsInGitRepo_IsOutside(t *testing.T) {
 }
 
 func TestPathIsInGitRepo_IsInside(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "sturdy")
-	assert.NoError(t, err)
+	tmpDir := t.TempDir()
 	cmd := exec.Command("git", "init")
 	cmd.Dir = tmpDir
-	err = cmd.Run()
+	err := cmd.Run()
 	assert.NoError(t, err)
 
 	is, gitPath := pathIsInGitRepo(tmpDir)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```