### PR TITLE
vcs/executor: set minimum limit of temporary repos to 3

### DIFF
--- a/api/vcs/executor/executor_provider.go
+++ b/api/vcs/executor/executor_provider.go
@@ -11,20 +11,22 @@ type Provider interface {
 }
 
 type executorProvider struct {
-	logger       *zap.Logger
-	repoProvider provider.RepoProvider
+	logger           *zap.Logger
+	repoProvider     provider.RepoProvider
+	minTmpBufferSize int
 
 	locks *locker
 }
 
-func NewProvider(logger *zap.Logger, repoProvider provider.RepoProvider) Provider {
+func NewProvider(logger *zap.Logger, repoProvider provider.RepoProvider, minTmpBufferSize int) Provider {
 	return &executorProvider{
-		logger:       logger.Named("gitExecutor"),
-		repoProvider: repoProvider,
-		locks:        newLocker(repoProvider),
+		logger:           logger.Named("gitExecutor"),
+		repoProvider:     repoProvider,
+		minTmpBufferSize: minTmpBufferSize,
+		locks:            newLocker(repoProvider),
 	}
 }
 
 func (p *executorProvider) New() Executor {
-	return newExecutor(p.logger, p.repoProvider, p.locks)
+	return newExecutor(p.logger, p.repoProvider, p.locks, p.minTmpBufferSize)
 }

--- a/api/vcs/executor/executor_test.go
+++ b/api/vcs/executor/executor_test.go
@@ -27,7 +27,7 @@ func syncMapSize(m *sync.Map) int {
 }
 
 func TestExecutor_TemporaryView_must_createtwo(t *testing.T) {
-	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t))
+	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t), 1)
 
 	codebaseID := codebases.ID("cb")
 
@@ -67,7 +67,7 @@ func TestExecutor_TemporaryView_must_createtwo(t *testing.T) {
 }
 
 func TestExecutor_TemporaryView_must_reuse(t *testing.T) {
-	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t))
+	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t), 1)
 
 	codebaseID := codebases.ID("cb")
 
@@ -88,7 +88,7 @@ func TestExecutor_TemporaryView_must_reuse(t *testing.T) {
 }
 
 func TestExecutor_AllowRebasingState(t *testing.T) {
-	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t))
+	exec := NewProvider(zap.NewNop(), testutil.TestingRepoProvider(t), 1)
 
 	// create repo
 	err := exec.New().AllowRebasingState().Schedule(func(repoProvider provider.RepoProvider) error {

--- a/api/vcs/executor/module.go
+++ b/api/vcs/executor/module.go
@@ -4,10 +4,13 @@ import (
 	"getsturdy.com/api/pkg/di"
 	"getsturdy.com/api/pkg/logger"
 	"getsturdy.com/api/vcs/provider"
+	"go.uber.org/zap"
 )
 
 func Module(c *di.Container) {
 	c.Import(logger.Module)
 	c.Import(provider.Module)
-	c.Register(NewProvider)
+	c.Register(func(logger *zap.Logger, repoProvider provider.RepoProvider) Provider {
+		return NewProvider(logger, repoProvider, 3)
+	})
 }


### PR DESCRIPTION
<p>vcs/executor: set minimum limit of temporary repos to 3</p><p>this should decrease chances of a race</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/44689e69-841e-4d16-99b3-8a3c02ad8565).

Update this PR by making changes through Sturdy.
