### PR TITLE
api/datamigrations: run on all codebases

### DIFF
--- a/api/pkg/datamigrations/migrations.go
+++ b/api/pkg/datamigrations/migrations.go
@@ -212,7 +212,6 @@ func (c *changesCodebaseIDCommitIDUniq) loadCodebaseIDsWithDuplicates(ctx contex
 				GROUP BY codebase_id, commit_id
 				HAVING COUNT(1) > 1
 			) AS t
-			WHERE codebase_id = 'b47c077a-e098-4eec-bb64-318f5a8571e3'
 			GROUP by codebase_id
 		`); err != nil {
 			c.codebaseIDsError = err


### PR DESCRIPTION
<p>api/datamigrations: run on all codebases</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/716710f9-3a6e-433a-8246-335110611f4a).

Update this PR by making changes through Sturdy.
