### PR TITLE
api/datamigrations: allow archived codebases

### DIFF
--- a/api/pkg/codebases/service/service.go
+++ b/api/pkg/codebases/service/service.go
@@ -72,12 +72,12 @@ func New(
 	}
 }
 
+func (svc *Service) GetByIDAllowArchived(ctx context.Context, id codebases.ID) (*codebases.Codebase, error) {
+	return svc.repo.GetAllowArchived(id)
+}
+
 func (svc *Service) GetByID(ctx context.Context, id codebases.ID) (*codebases.Codebase, error) {
-	cb, err := svc.repo.Get(id)
-	if err != nil {
-		return nil, err
-	}
-	return cb, nil
+	return svc.repo.Get(id)
 }
 
 func (svc *Service) GetByShortID(ctx context.Context, shortID codebases.ShortCodebaseID) (*codebases.Codebase, error) {

--- a/api/pkg/datamigrations/migrations.go
+++ b/api/pkg/datamigrations/migrations.go
@@ -176,7 +176,7 @@ func (c *changesCodebaseIDCommitIDUniq) ambiguousChangeIDs(ctx context.Context, 
 }
 
 func (c *changesCodebaseIDCommitIDUniq) codebaseChangeSet(ctx context.Context, id codebases.ID) (map[changes.ID]bool, error) {
-	codebase, err := c.codebasesService.GetByID(ctx, id)
+	codebase, err := c.codebasesService.GetByIDAllowArchived(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load codebase %s: %w", id, err)
 	}


### PR DESCRIPTION
<p>api/datamigrations: allow archived codebases</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/359c95d5-e5bd-4acd-a965-1d5f2ec3ec45).

Update this PR by making changes through Sturdy.
