### PR TITLE
api/pkg/integrations: use dependency injection to register providers

### DIFF
--- a/api/pkg/ci/service/module.go
+++ b/api/pkg/ci/service/module.go
@@ -5,6 +5,7 @@ import (
 	configuration "getsturdy.com/api/pkg/configuration/module"
 	"getsturdy.com/api/pkg/di"
 	db_integrations "getsturdy.com/api/pkg/integrations/db"
+	integration_providers "getsturdy.com/api/pkg/integrations/providers/module"
 	service_jwt "getsturdy.com/api/pkg/jwt/service"
 	"getsturdy.com/api/pkg/logger"
 	"getsturdy.com/api/pkg/snapshots/snapshotter"
@@ -21,5 +22,6 @@ func Module(c *di.Container) {
 	c.Import(service_statuses.Module)
 	c.Import(service_jwt.Module)
 	c.Import(snapshotter.Module)
+	c.Import(integration_providers.Module)
 	c.Register(New)
 }

--- a/api/pkg/integrations/graphql/module.go
+++ b/api/pkg/integrations/graphql/module.go
@@ -6,6 +6,7 @@ import (
 	service_ci "getsturdy.com/api/pkg/ci/service"
 	"getsturdy.com/api/pkg/di"
 	graphql_buildkite "getsturdy.com/api/pkg/integrations/providers/buildkite/graphql"
+	integration_providers "getsturdy.com/api/pkg/integrations/providers/module"
 	graphql_statuses "getsturdy.com/api/pkg/statuses/graphql/module"
 	service_workspaces "getsturdy.com/api/pkg/workspaces/service"
 )
@@ -17,5 +18,6 @@ func Module(c *di.Container) {
 	c.Import(service_workspaces.Module)
 	c.Import(graphql_buildkite.Module)
 	c.Import(graphql_statuses.Module)
+	c.Import(integration_providers.Module)
 	c.Register(NewRootResolver)
 }

--- a/api/pkg/integrations/providers/buildkite/enterprise/service/service.go
+++ b/api/pkg/integrations/providers/buildkite/enterprise/service/service.go
@@ -21,11 +21,9 @@ type Service struct {
 }
 
 func New(configRepo db_buildkite.Repository) *Service {
-	s := &Service{
+	return &Service{
 		configRepo: configRepo,
 	}
-	providers.Register(s)
-	return s
 }
 
 func (b *Service) ProviderType() providers.ProviderType {

--- a/api/pkg/integrations/providers/module/module_enterprise.go
+++ b/api/pkg/integrations/providers/module/module_enterprise.go
@@ -1,0 +1,19 @@
+//go:build enterprise || cloud
+
+package module
+
+import (
+	"getsturdy.com/api/pkg/di"
+	"getsturdy.com/api/pkg/integrations/providers"
+	service_buildkite "getsturdy.com/api/pkg/integrations/providers/buildkite/enterprise/service"
+)
+
+func Module(c *di.Container) {
+	c.Import(service_buildkite.Module)
+
+	c.Register(func(buildkite *service_buildkite.Service) providers.Providers {
+		return providers.Providers{
+			buildkite.ProviderName(): buildkite,
+		}
+	})
+}

--- a/api/pkg/integrations/providers/module/module_oss.go
+++ b/api/pkg/integrations/providers/module/module_oss.go
@@ -1,0 +1,14 @@
+//go:build !enterprise && !cloud
+
+package module
+
+import (
+	"getsturdy.com/api/pkg/di"
+	"getsturdy.com/api/pkg/integrations/providers"
+)
+
+func Module(c *di.Container) {
+	c.Register(func() providers.Providers {
+		return providers.Providers{}
+	})
+}

--- a/api/pkg/integrations/providers/provider.go
+++ b/api/pkg/integrations/providers/provider.go
@@ -14,12 +14,6 @@ type BuildProvider interface {
 	CreateBuild(ctx context.Context, codebaseID, ciCommitId, title string) (*Build, error)
 }
 
-type PushPullProvider interface {
-	Provider
-	Push(ctx context.Context, codebaseID string) error
-	Pull(ctx context.Context, codebaseID string) error
-}
-
 type ProviderType string
 
 const (
@@ -32,6 +26,7 @@ type ProviderName string
 const (
 	ProviderNameUndefined ProviderName = ""
 	ProviderNameBuildkite ProviderName = "buildkite"
+	ProviderNameGithub    ProviderName = "github"
 )
 
 type Build struct {

--- a/api/pkg/integrations/providers/providers.go
+++ b/api/pkg/integrations/providers/providers.go
@@ -9,17 +9,11 @@ var (
 	ErrNotFound = fmt.Errorf("provider not found")
 )
 
-var registry = map[ProviderName]Provider{}
+type Providers map[ProviderName]Provider
 
-func Register(p Provider) {
-	registry[p.ProviderName()] = p
-}
-
-func Get[T any](name ProviderName) (res T, err error) {
-	if provider, ok := registry[name]; ok {
-		if t, ok := provider.(T); ok {
-			return t, nil
-		}
+func (p Providers) Get(name ProviderName) (res Provider, err error) {
+	if provider, ok := p[name]; ok {
+		return provider, nil
 	}
 	err = ErrNotFound
 	return


### PR DESCRIPTION
<p>api/pkg/integrations: use dependency injection to register providers</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/55f647ba-928c-4427-ae74-268d616567b7).

Update this PR by making changes through Sturdy.
