### PR TITLE
api/changes: rely on db index instead of in-memory lock

### DIFF
--- a/api/pkg/github/enterprise/service/pull_request.go
+++ b/api/pkg/github/enterprise/service/pull_request.go
@@ -293,7 +293,6 @@ func (svc *Service) mergePullRequest(
 
 	ch, err := svc.changeService.CreateWithCommitAsParent(ctx, ws, gitHubPR.GetMergeCommitSHA(), gitHubPR.GetBase().GetSHA())
 	if errors.Is(err, service_change.ErrAlreadyExists) {
-		// noop
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to create change: %w", err)


### PR DESCRIPTION
<p>api/changes: rely on db index instead of in-memory lock</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/5680cb24-c088-41c3-a173-b9ac9f3c79ad).

Update this PR by making changes through Sturdy.
