### PR TITLE
api/pkg/di: add test to verify that the container fails if there are two implementations of the same interface registered

### DIFF
--- a/api/pkg/di/container_test.go
+++ b/api/pkg/di/container_test.go
@@ -170,3 +170,27 @@ func TestContainer_ImportRegisterWithForce(t *testing.T) {
 		assert.Equal(t, 3, i)
 	}
 }
+
+func TestContainer_ImportDuplicateAlternativeImplementations(t *testing.T) {
+	type Something interface{}
+
+	type SomethingV1 struct{}
+	type SomethingV2 struct{}
+
+	c1 := func(c *Container) {
+		c.Register(func() Something { return &SomethingV1{} })
+	}
+
+	c2 := func(c *Container) {
+		c.Register(func() Something { return &SomethingV2{} })
+	}
+
+	c3 := func(c *Container) {
+		c.Import(c1)
+		c.Import(c2)
+	}
+
+	var something Something
+	err := Init(c3).To(&something)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<p>api/pkg/di: add test to verify that the container fails if there are two implementations of the same interface registered</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/4cb72623-0bac-4660-bb48-4667b9891020).

Update this PR by making changes through Sturdy.
