### PR TITLE
api/gc: list snapshots to cleanup based on view branches

### DIFF
--- a/api/pkg/snapshots/db/memory.go
+++ b/api/pkg/snapshots/db/memory.go
@@ -3,9 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
-	"time"
 
-	"getsturdy.com/api/pkg/codebases"
 	"getsturdy.com/api/pkg/snapshots"
 )
 
@@ -42,18 +40,20 @@ func (f *snapshotRepo) Get(ID string) (*snapshots.Snapshot, error) {
 	return nil, sql.ErrNoRows
 }
 
-func (f *snapshotRepo) ListUndeletedInCodebase(_ codebases.ID, _ time.Time) ([]*snapshots.Snapshot, error) {
-	panic("not implemented")
-}
-
 func (f *snapshotRepo) Update(*snapshots.Snapshot) error {
-	panic("not implemented")
-}
-
-func (f *snapshotRepo) ListByViewCopiedFromBranchName(copiedFromBranchName string) ([]*snapshots.Snapshot, error) {
 	panic("not implemented")
 }
 
 func (f *snapshotRepo) GetByCommitSHA(_ context.Context, sha string) (*snapshots.Snapshot, error) {
 	panic("not implemented")
+}
+
+func (f *snapshotRepo) ListByIDs(ctx context.Context, ids []string) ([]*snapshots.Snapshot, error) {
+	res := []*snapshots.Snapshot{}
+	for _, id := range ids {
+		if snap, ok := f.byID[id]; ok {
+			res = append(res, snap)
+		}
+	}
+	return res, nil
 }

--- a/api/pkg/snapshots/db/repo.go
+++ b/api/pkg/snapshots/db/repo.go
@@ -3,21 +3,20 @@ package db
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"getsturdy.com/api/pkg/codebases"
 	"getsturdy.com/api/pkg/snapshots"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type Repository interface {
 	Create(snapshot *snapshots.Snapshot) error
 	LatestInWorkspace(context.Context, string) (*snapshots.Snapshot, error)
 	GetByCommitSHA(context.Context, string) (*snapshots.Snapshot, error)
+	ListByIDs(context.Context, []string) ([]*snapshots.Snapshot, error)
 	Get(string) (*snapshots.Snapshot, error)
 	Update(snapshot *snapshots.Snapshot) error
-	ListUndeletedInCodebase(codebaseID codebases.ID, threshold time.Time) ([]*snapshots.Snapshot, error)
 }
 
 type dbrepo struct {
@@ -65,34 +64,6 @@ func (r *dbrepo) LatestInWorkspace(ctx context.Context, workspaceID string) (*sn
 	return &res, nil
 }
 
-func (r *dbrepo) ListUndeletedInCodebase(codebaseID codebases.ID, threshold time.Time) ([]*snapshots.Snapshot, error) {
-	var res []*snapshots.Snapshot
-	err := r.db.Select(&res, `
-		SELECT 
-			id,
-			view_id,
-			created_at,
-			previous_snapshot_id,
-			codebase_id,
-			commit_id,
-			workspace_id,
-			action,
-			diffs_count
-		FROM 
-			snapshots
-		WHERE codebase_id = $1
-	      AND deleted_at IS NULL
-		  AND created_at < $2
-		ORDER BY 
-		  created_at DESC
-		LIMIT 1000
-		`, codebaseID, threshold)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list undeleted in codebase: %w", err)
-	}
-	return res, nil
-}
-
 func (r *dbrepo) Update(snapshot *snapshots.Snapshot) error {
 	_, err := r.db.NamedExec(`UPDATE snapshots
 		SET deleted_at = :deleted_at
@@ -113,4 +84,17 @@ func (r *dbrepo) GetByCommitSHA(ctx context.Context, sha string) (*snapshots.Sna
 		return nil, fmt.Errorf("failed to get by commit sha: %w", err)
 	}
 	return &res, nil
+}
+
+func (r *dbrepo) ListByIDs(ctx context.Context, ids []string) ([]*snapshots.Snapshot, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var res []*snapshots.Snapshot
+	if err := r.db.SelectContext(ctx, &res, `SELECT id, view_id, created_at, previous_snapshot_id, codebase_id, commit_id, workspace_id,  action, diffs_count
+		FROM snapshots
+		WHERE id = ANY($1)`, pq.Array(ids)); err != nil {
+		return nil, fmt.Errorf("failed to list by ids: %w", err)
+	}
+	return res, nil
 }

--- a/api/vcs/git_test.go
+++ b/api/vcs/git_test.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	git "github.com/libgit2/git2go/v33"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +22,7 @@ func TestListBranches(t *testing.T) {
 	assert.NoError(t, repo.CreateNewBranchOnHEAD("foo-2"))
 	assert.NoError(t, repo.CreateNewBranchOnHEAD("foo-3"))
 
-	branches, err := repo.listBranches()
+	branches, err := repo.listBranches(git.BranchAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"foo-1", "foo-2", "foo-3", "master", "sturdytrunk"}, branches)

--- a/api/vcs/repository.go
+++ b/api/vcs/repository.go
@@ -27,6 +27,7 @@ type RepoGitReader interface {
 
 	HeadBranch() (string, error)
 	HeadCommit() (*git.Commit, error)
+	Branches() ([]string, error)
 
 	BranchCommitID(branchName string) (string, error)
 


### PR DESCRIPTION
<p>api/gc: list snapshots to cleanup based on view branches</p><p>this removes the last usage of snapshot.ViewID in the codebase</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/e5ec09f7-a2a2-4d41-bc8d-0888714da8fa).

Update this PR by making changes through Sturdy.
