### PR TITLE
api/logger: do not send pq cancel errors to sentry

### DIFF
--- a/api/pkg/logger/enterprise/cloud/sentry/client.go
+++ b/api/pkg/logger/enterprise/cloud/sentry/client.go
@@ -10,9 +10,12 @@ import (
 
 func NewClient() (*sentry.Client, error) {
 	return sentry.NewClient(sentry.ClientOptions{
-		Dsn:          "https://7ca135fcbbbc4fa3bf816695f743c98f@o952367.ingest.sentry.io/6177866",
-		ServerName:   version.Type.String(),
-		Release:      version.Version,
-		IgnoreErrors: []string{context.Canceled.Error()},
+		Dsn:        "https://7ca135fcbbbc4fa3bf816695f743c98f@o952367.ingest.sentry.io/6177866",
+		ServerName: version.Type.String(),
+		Release:    version.Version,
+		IgnoreErrors: []string{
+			context.Canceled.Error(),
+			"pq: canceling statement due to user request",
+		},
 	})
 }


### PR DESCRIPTION
<p>api/logger: do not send pq cancel errors to sentry</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/1f31927a-805f-475b-9db3-17244a491ae7).

Update this PR by making changes through Sturdy.
