### PR TITLE
api/pkg/snapshots: user friendly commit messages

### DIFF
--- a/api/pkg/ci/service/module.go
+++ b/api/pkg/ci/service/module.go
@@ -5,6 +5,7 @@ import (
 	db_ci "getsturdy.com/api/pkg/ci/db"
 	configuration "getsturdy.com/api/pkg/configuration/module"
 	"getsturdy.com/api/pkg/di"
+	service_github "getsturdy.com/api/pkg/github/service/module"
 	db_integrations "getsturdy.com/api/pkg/integrations/db"
 	service_jwt "getsturdy.com/api/pkg/jwt/service"
 	"getsturdy.com/api/pkg/logger"
@@ -23,5 +24,6 @@ func Module(c *di.Container) {
 	c.Import(service_jwt.Module)
 	c.Import(service_snapshots.Module)
 	c.Import(service_buildkite.Module)
+	c.Import(service_github.Module)
 	c.Register(New)
 }

--- a/api/pkg/land/service/service.go
+++ b/api/pkg/land/service/service.go
@@ -179,7 +179,7 @@ func (s *Service) LandChange(ctx context.Context, ws *workspaces.Workspace, diff
 	)
 
 	if ws.ViewID != nil {
-		if err := s.snapshotterQueue.Enqueue(ctx, ws.CodebaseID, *ws.ViewID, ws.ID, snapshots.ActionChangeLand); err != nil {
+		if err := s.snapshotterQueue.Enqueue(ctx, ws.CodebaseID, *ws.ViewID, ws.ID, ws.UserID, snapshots.ActionChangeLand); err != nil {
 			return nil, fmt.Errorf("failed to enqueue snapshot: %w", err)
 		}
 

--- a/api/pkg/mutagen/routes/transition.go
+++ b/api/pkg/mutagen/routes/transition.go
@@ -75,7 +75,7 @@ func SyncTransitions(
 		}
 
 		// Make a snapshot
-		if err := snapshotterQueue.Enqueue(c, req.CodebaseID, req.ViewID, view.WorkspaceID, snapshots.ActionViewSync); err != nil {
+		if err := snapshotterQueue.Enqueue(c, req.CodebaseID, req.ViewID, view.WorkspaceID, view.UserID, snapshots.ActionViewSync); err != nil {
 			logger.Error("failed to snapshot", zap.Error(err))
 			// Don't fail
 		}

--- a/api/pkg/snapshots/vcs/snapshots_test.go
+++ b/api/pkg/snapshots/vcs/snapshots_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
+
+	git "github.com/libgit2/git2go/v33"
 
 	"getsturdy.com/api/pkg/codebases"
 	codebasevcs "getsturdy.com/api/pkg/codebases/vcs"
@@ -63,8 +66,14 @@ func TestSnapshot(t *testing.T) {
 	assert.NoError(t, ioutil.WriteFile(viewPath+"/a.txt", []byte("hello a"), 0o666))
 	assert.NoError(t, ioutil.WriteFile(viewPath+"/b.txt", []byte("hello b"), 0o666))
 
+	sig := git.Signature{
+		Name:  "test",
+		Email: "test@example.com",
+		When:  time.Now(),
+	}
+
 	// Snapshot
-	firstSnapshotCommitID, err := SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String())
+	firstSnapshotCommitID, err := SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String(), sig)
 	assert.NoError(t, err)
 	diffs, _, err := viewRepo.ShowCommit(firstSnapshotCommitID)
 	assert.NoError(t, err)
@@ -79,7 +88,7 @@ func TestSnapshot(t *testing.T) {
 	// Update files some more and snapshot
 	assert.NoError(t, ioutil.WriteFile(viewPath+"/a.txt", []byte("hello a2"), 0o666))
 	assert.NoError(t, ioutil.WriteFile(viewPath+"/b.txt", []byte("hello b2"), 0o666))
-	secondSnapshotCommitID, err := SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String())
+	secondSnapshotCommitID, err := SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String(), sig)
 	assert.NoError(t, err)
 
 	diffs, _, err = viewRepo.ShowCommit(secondSnapshotCommitID)
@@ -129,7 +138,7 @@ func TestSnapshot(t *testing.T) {
 	// Remove a file and snapshot
 	assert.NoError(t, os.Remove(viewPath+"/a.txt"))
 	assert.NoError(t, ioutil.WriteFile(viewPath+"/b.txt", []byte("hello b3"), 0o666))
-	_, err = SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String())
+	_, err = SnapshotOnViewRepo(zap.NewNop(), viewRepo, codebaseID, uuid.New().String(), sig)
 	assert.NoError(t, err)
 
 	// TODO: Verify snapshot commits, current working directory, etc.

--- a/api/pkg/snapshots/worker/mock.go
+++ b/api/pkg/snapshots/worker/mock.go
@@ -2,22 +2,36 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	"getsturdy.com/api/pkg/codebases"
 	"getsturdy.com/api/pkg/snapshots"
 	service_snapshots "getsturdy.com/api/pkg/snapshots/service"
+	"getsturdy.com/api/pkg/users"
+	service_users "getsturdy.com/api/pkg/users/service"
 )
 
 type inProcessPublisher struct {
-	snapshotter *service_snapshots.Service
+	snapshotter  *service_snapshots.Service
+	usersService service_users.Service
 }
 
-func NewSync(snapshotter *service_snapshots.Service) Queue {
-	return &inProcessPublisher{snapshotter: snapshotter}
+func NewSync(
+	snapshotter *service_snapshots.Service,
+	usersService service_users.Service,
+) Queue {
+	return &inProcessPublisher{
+		snapshotter:  snapshotter,
+		usersService: usersService,
+	}
 }
 
-func (p *inProcessPublisher) Enqueue(_ context.Context, codebaseID codebases.ID, viewID, workspaceID string, action snapshots.Action) error {
-	_, err := p.snapshotter.Snapshot(codebaseID, workspaceID, action, service_snapshots.WithOnView(viewID))
+func (p *inProcessPublisher) Enqueue(ctx context.Context, codebaseID codebases.ID, viewID, workspaceID string, userID users.ID, action snapshots.Action) error {
+	user, err := p.usersService.GetByID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("failed to get user: %w", err)
+	}
+	_, err = p.snapshotter.Snapshot(codebaseID, workspaceID, action, service_snapshots.WithOnView(viewID), service_snapshots.WithUser(user))
 	if err != nil {
 		return err
 	}

--- a/api/pkg/snapshots/worker/module.go
+++ b/api/pkg/snapshots/worker/module.go
@@ -5,12 +5,14 @@ import (
 	"getsturdy.com/api/pkg/logger"
 	queue "getsturdy.com/api/pkg/queue/module"
 	service_snapshots "getsturdy.com/api/pkg/snapshots/service"
+	service_users "getsturdy.com/api/pkg/users/service/module"
 )
 
 func Module(c *di.Container) {
 	c.Import(logger.Module)
 	c.Import(queue.Module)
 	c.Import(service_snapshots.Module)
+	c.Import(service_users.Module)
 	c.Register(New)
 }
 

--- a/api/pkg/view/meta/updated.go
+++ b/api/pkg/view/meta/updated.go
@@ -28,7 +28,7 @@ func NewViewUpdatedFunc(
 		}
 
 		// Add to snapshotter queue
-		if err := snapshotterQueue.Enqueue(ctx, view.CodebaseID, view.ID, view.WorkspaceID, action); err != nil {
+		if err := snapshotterQueue.Enqueue(ctx, view.CodebaseID, view.ID, view.WorkspaceID, view.UserID, action); err != nil {
 			return fmt.Errorf("failed to enqueue snapshot: %w", err)
 		}
 

--- a/api/vcs/git.go
+++ b/api/vcs/git.go
@@ -280,15 +280,20 @@ func (repo *repository) DeleteFile(fileName string) error {
 
 func (repo *repository) AddAndCommit(msg string) (string, error) {
 	defer getMeterFunc("AddAndCommit")()
-
-	oid, err := repo.AddFilesToIndex([]string{"."})
-	if err != nil {
-		return "", fmt.Errorf("failed to add changes to index: %w", err)
-	}
 	sig := git.Signature{
 		Name:  "Sturdy",
 		Email: "support@getsturdy.com",
 		When:  time.Now(),
+	}
+	return repo.AddAndCommitWithSignature(msg, sig)
+}
+
+func (repo *repository) AddAndCommitWithSignature(msg string, sig git.Signature) (string, error) {
+	defer getMeterFunc("AddAndCommit")()
+
+	oid, err := repo.AddFilesToIndex([]string{"."})
+	if err != nil {
+		return "", fmt.Errorf("failed to add changes to index: %w", err)
 	}
 	commitID, err := repo.CommitIndexTree(oid, msg, sig)
 	if err != nil {

--- a/api/vcs/repository.go
+++ b/api/vcs/repository.go
@@ -106,6 +106,7 @@ type RepoReader interface {
 
 	AddFilesToIndex(files []string) (*git.Oid, error)
 	AddAndCommit(msg string) (string, error)
+	AddAndCommitWithSignature(msg string, sig git.Signature) (string, error)
 
 	LargeFilesClean(codebaseID codebases.ID, paths []string) ([][]byte, error)
 


### PR DESCRIPTION
<p>api/pkg/snapshots: user friendly commit messages</p><p>Prepare for being able to push snapshots to external providers, so let’s make them a little bit nicer by attributing them to a user (when we can).</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/1f13c42e-2e56-4515-b42c-f91108b2f4f1).

Update this PR by making changes through Sturdy.
