### PR TITLE
api/workspaces: set correct latest snapshot id while undoing

### DIFF
--- a/api/pkg/workspaces/service/service.go
+++ b/api/pkg/workspaces/service/service.go
@@ -281,7 +281,7 @@ func (s *Service) Undo(ctx context.Context, ws *workspaces.Workspace) error {
 	if err := s.workspaceWriter.UpdateFields(ctx, ws.ID, db.SetLatestSnapshotID(&previousSnapshot.ID)); err != nil {
 		return fmt.Errorf("failed to update workspace: %w", err)
 	}
-	ws.LatestSnapshotID = latestSnapshot.PreviousSnapshotID
+	ws.LatestSnapshotID = &latestSnapshot.ID
 
 	return nil
 }


### PR DESCRIPTION
<p>api/workspaces: set correct latest snapshot id while undoing</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/cc40a3c1-60d6-4d8c-a431-3722a79e8939).

Update this PR by making changes through Sturdy.
