### PR TITLE
api/pkg/downloads: more reliably create archives based on snapshots

### DIFF
--- a/api/pkg/downloads/enterprise/cloud/graphql/root.go
+++ b/api/pkg/downloads/enterprise/cloud/graphql/root.go
@@ -85,7 +85,7 @@ func (r *ContentsDownloadURLRootResolver) downloadChange(ctx context.Context, ch
 		return nil, gqlerrors.Error(err)
 	}
 
-	url, err := r.service.CreateArchive(ctx, allower, change.CodebaseID, *change.CommitID, format)
+	url, err := r.service.CreateArchive(ctx, allower, change.CodebaseID, "sturdytrunk", *change.CommitID, format)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}


### PR DESCRIPTION
<p>api/pkg/downloads: more reliably create archives based on snapshots</p><p>Make sure that the correct snapshot is available on the view where the snapshot runs.</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/966eec28-e7cd-4c8b-8088-0c51c52c9855).

Update this PR by making changes through Sturdy.
