### PR TITLE
api/pkg/statuses: mark workspace statuses as stale when a new snapshot is made

### DIFF
--- a/api/pkg/downloads/enterprise/cloud/graphql/root.go
+++ b/api/pkg/downloads/enterprise/cloud/graphql/root.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 
 	service_auth "getsturdy.com/api/pkg/auth/service"
 	"getsturdy.com/api/pkg/changes"
@@ -67,7 +68,7 @@ func (r *ContentsDownloadURLRootResolver) downloadWorkspace(ctx context.Context,
 		return nil, gqlerrors.Error(err)
 	}
 
-	url, err := r.service.CreateArchive(ctx, allower, snapshot.CodebaseID, snapshot.CommitSHA, format)
+	url, err := r.service.CreateArchive(ctx, allower, snapshot.CodebaseID, fmt.Sprintf("snapshot-%s", snapshot.ID), snapshot.CommitSHA, format)
 	if err != nil {
 		return nil, gqlerrors.Error(err)
 	}

--- a/api/pkg/snapshots/service/module.go
+++ b/api/pkg/snapshots/service/module.go
@@ -7,6 +7,7 @@ import (
 	eventsv2 "getsturdy.com/api/pkg/events/v2"
 	"getsturdy.com/api/pkg/logger"
 	db_snapshots "getsturdy.com/api/pkg/snapshots/db"
+	service_statuses "getsturdy.com/api/pkg/statuses/service"
 	db_suggestions "getsturdy.com/api/pkg/suggestions/db"
 	db_view "getsturdy.com/api/pkg/view/db"
 	db_workspaces "getsturdy.com/api/pkg/workspaces/db"
@@ -25,5 +26,6 @@ func Module(c *di.Container) {
 	c.Import(db_suggestions.Module)
 	c.Import(executor.Module)
 	c.Import(service_analytics.Module)
+	c.Import(service_statuses.Module)
 	c.Register(New)
 }

--- a/api/pkg/statuses/service/service.go
+++ b/api/pkg/statuses/service/service.go
@@ -77,3 +77,18 @@ func (s *Service) ListByWorkspaceID(ctx context.Context, workspaceID string) ([]
 	}
 	return latestStatuses, nil
 }
+
+func (s *Service) NotifyAllInWorkspace(ctx context.Context, workspaceID string) error {
+	statusList, err := s.ListByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return fmt.Errorf("failed to get statuses: %w", err)
+	}
+
+	for _, status := range statusList {
+		if err := s.eventsPublisher.StatusUpdated(ctx, events.Codebase(status.CodebaseID), status); err != nil {
+			s.logger.Error("failed to send status updated event", zap.Error(err))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<p>api/pkg/statuses: mark workspace statuses as stale when a new snapshot is made</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/f3637d22-f184-44df-a891-438d316db680).

Update this PR by making changes through Sturdy.
