### PR TITLE
api/pkg/ci: use pinned snapshot when downloading a workspace

### DIFF
--- a/api/pkg/snapshots/db/repo.go
+++ b/api/pkg/snapshots/db/repo.go
@@ -46,7 +46,7 @@ func (r *dbrepo) Get(id string) (*snapshots.Snapshot, error) {
 		WHERE id=$1
 		AND deleted_at IS NULL`, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get: %w", err)
+		return nil, fmt.Errorf("failed to get snapshot: %w", err)
 	}
 	return &res, nil
 }


### PR DESCRIPTION
<p>api/pkg/ci: use pinned snapshot when downloading a workspace</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/e92664cd-af24-4818-919b-80adb382540f).

Update this PR by making changes through Sturdy.
