### PR TITLE
web/relativeTime: use date-fns to format time

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "@vue/apollo-option": "~4.0.0-alpha.11",
     "@vueuse/core": "~6.4.0",
     "@vueuse/head": "~0.7.2",
+    "date-fns": "^2.28.0",
     "diff2html": "~3.4.13",
     "emoji-js": "~3.6.0",
     "graphql": "~15.5.0",

--- a/web/src/atoms/RelativeTime.vue
+++ b/web/src/atoms/RelativeTime.vue
@@ -8,14 +8,25 @@ import { defineComponent } from 'vue'
 
 export default defineComponent({
   props: {
-    date: {
-      type: Date,
-      required: true,
-    },
+    date: { type: Date, required: true },
+  },
+  data() {
+    return {
+      from: new Date(),
+      interval: null as null | ReturnType<typeof setInterval>,
+    }
+  },
+  mounted() {
+    this.interval = setInterval(() => {
+      this.from = new Date()
+    }, 1000)
+  },
+  unmounted() {
+    if (this.interval) clearInterval(this.interval)
   },
   computed: {
     ago(): string {
-      return time.getRelativeTime(this.date)
+      return time.getRelativeTime(this.date, this.from)
     },
   },
 })

--- a/web/src/time.ts
+++ b/web/src/time.ts
@@ -1,29 +1,6 @@
-const units: { [key: string]: number } = {
-  year: 24 * 60 * 60 * 1000 * 365,
-  month: (24 * 60 * 60 * 1000 * 365) / 12,
-  day: 24 * 60 * 60 * 1000,
-  hour: 60 * 60 * 1000,
-  minute: 60 * 1000,
-  second: 1000,
-}
-
-const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
+import { formatDistanceStrict } from 'date-fns'
 
 export default {
-  getRelativeTime: function (d1: Date, d2 = new Date(), justNowMessage = 'just now'): string {
-    const elapsed = d1.getTime() - d2.getTime()
-
-    if (Math.abs(elapsed) < units.minute) {
-      return justNowMessage
-    }
-
-    // "Math.abs" accounts for both "past" & "future" scenarios
-    for (const u in units) {
-      if (Math.abs(elapsed) > units[u] || u === 'second') {
-        return rtf.format(Math.round(elapsed / units[u]), u as Intl.RelativeTimeFormatUnit)
-      }
-    }
-
-    return ''
-  },
+  getRelativeTime: (date: Date, baseDate = new Date()): string =>
+    formatDistanceStrict(date, baseDate),
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5341,6 +5341,11 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
<p>web/relativeTime: use date-fns to format time</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/f1e01338-cf6c-4bd6-886c-928000349407).

Update this PR by making changes through Sturdy.
