### PR TITLE
api/events: move workspace watcher event to v2

### DIFF
--- a/api/pkg/events/events.go
+++ b/api/pkg/events/events.go
@@ -45,21 +45,19 @@ const (
 	WorkspaceUpdatedPresence
 	WorkspaceUpdatedSuggestion
 	NotificationEvent
-	WorkspaceWatchingStatusUpdated
 )
 
 var eventTypeString = map[EventType]string{
-	CodebaseEvent:                  "CodebaseEvent",
-	CodebaseUpdated:                "CodebaseUpdated",
-	WorkspaceUpdated:               "WorkspaceUpdated",
-	WorkspaceUpdatedComments:       "WorkspaceUpdatedComments",
-	WorkspaceUpdatedReviews:        "WorkspaceUpdatedReviews",
-	WorkspaceUpdatedActivity:       "WorkspaceUpdatedActivity",
-	WorkspaceUpdatedPresence:       "WorkspaceUpdatedPresence",
-	WorkspaceUpdatedSuggestion:     "WorkspaceUpdatedSuggestion",
-	ReviewUpdated:                  "ReviewUpdated",
-	NotificationEvent:              "NotificationEvent",
-	WorkspaceWatchingStatusUpdated: "WorkspaceWatchingStatusUpdated",
+	CodebaseEvent:              "CodebaseEvent",
+	CodebaseUpdated:            "CodebaseUpdated",
+	WorkspaceUpdated:           "WorkspaceUpdated",
+	WorkspaceUpdatedComments:   "WorkspaceUpdatedComments",
+	WorkspaceUpdatedReviews:    "WorkspaceUpdatedReviews",
+	WorkspaceUpdatedActivity:   "WorkspaceUpdatedActivity",
+	WorkspaceUpdatedPresence:   "WorkspaceUpdatedPresence",
+	WorkspaceUpdatedSuggestion: "WorkspaceUpdatedSuggestion",
+	ReviewUpdated:              "ReviewUpdated",
+	NotificationEvent:          "NotificationEvent",
 }
 
 type CallbackFunc func(eventType EventType, reference string) error

--- a/api/pkg/events/v2/publisher.go
+++ b/api/pkg/events/v2/publisher.go
@@ -16,6 +16,7 @@ import (
 	db_codebases "getsturdy.com/api/pkg/codebases/db"
 	db_organization "getsturdy.com/api/pkg/organization/db"
 	db_workspaces "getsturdy.com/api/pkg/workspaces/db"
+	"getsturdy.com/api/pkg/workspaces/watchers"
 )
 
 type Publisher struct {
@@ -194,15 +195,15 @@ func (p *Publisher) WorkspaceUpdatedSuggestion(ctx context.Context, receiver *re
 	return nil
 }
 
-func (p *Publisher) WorkspaceWatchingStatusUpdated(ctx context.Context, receiver *receiver, workspace *workspaces.Workspace) error {
+func (p *Publisher) WorkspaceWatchingStatusUpdated(ctx context.Context, receiver *receiver, watcher *watchers.Watcher) error {
 	topics, err := receiver.Topics(ctx, p.codebaseUserRepo, p.workspaceRepo, p.organizationMemberRepo)
 	if err != nil {
 		return err
 	}
 	for topic := range topics {
 		p.pubSub.pub(topic, &event{
-			Type:      WorkspaceWatchingStatusUpdated,
-			Workspace: workspace,
+			Type:             WorkspaceWatchingStatusUpdated,
+			WorkspaceWatcher: watcher,
 		})
 	}
 	return nil

--- a/api/pkg/events/v2/subscriber.go
+++ b/api/pkg/events/v2/subscriber.go
@@ -13,6 +13,7 @@ import (
 	"getsturdy.com/api/pkg/users"
 	"getsturdy.com/api/pkg/view"
 	"getsturdy.com/api/pkg/workspaces"
+	"getsturdy.com/api/pkg/workspaces/watchers"
 )
 
 type Subscriber struct {
@@ -97,9 +98,9 @@ func (s *Subscriber) OnWorkspaceUpdatedSuggestion(ctx context.Context, topic Top
 	}, topic, WorkspaceUpdatedSuggestion)
 }
 
-func (s *Subscriber) OnWorkspaceWatchingStatusUpdated(ctx context.Context, topic Topic, callback func(context.Context, *workspaces.Workspace) error) {
+func (s *Subscriber) OnWorkspaceWatchingStatusUpdated(ctx context.Context, topic Topic, callback func(context.Context, *watchers.Watcher) error) {
 	s.pubsub.sub(ctx, func(ctx context.Context, event *event) error {
-		return callback(ctx, event.Workspace)
+		return callback(ctx, event.WorkspaceWatcher)
 	}, topic, WorkspaceWatchingStatusUpdated)
 }
 

--- a/api/pkg/workspaces/watchers/graphql/module.go
+++ b/api/pkg/workspaces/watchers/graphql/module.go
@@ -3,7 +3,7 @@ package graphql
 import (
 	service_auth "getsturdy.com/api/pkg/auth/service"
 	"getsturdy.com/api/pkg/di"
-	"getsturdy.com/api/pkg/events"
+	"getsturdy.com/api/pkg/events/v2"
 	"getsturdy.com/api/pkg/graphql/resolvers"
 	"getsturdy.com/api/pkg/logger"
 	service_workspace "getsturdy.com/api/pkg/workspaces/service"

--- a/api/pkg/workspaces/watchers/graphql/root.go
+++ b/api/pkg/workspaces/watchers/graphql/root.go
@@ -6,7 +6,7 @@ import (
 
 	"getsturdy.com/api/pkg/auth"
 	service_auth "getsturdy.com/api/pkg/auth/service"
-	"getsturdy.com/api/pkg/events"
+	"getsturdy.com/api/pkg/events/v2"
 	gqlerrors "getsturdy.com/api/pkg/graphql/errors"
 	"getsturdy.com/api/pkg/graphql/resolvers"
 	"getsturdy.com/api/pkg/workspaces"
@@ -24,7 +24,7 @@ type rootResolver struct {
 
 	authService *service_auth.Service
 
-	eventsReader events.EventReader
+	eventsReader *events.Subscriber
 
 	userRootResover       *resolvers.UserRootResolver
 	workspaceRootResolver *resolvers.WorkspaceRootResolver
@@ -38,7 +38,7 @@ func NewRootResolver(
 
 	authService *service_auth.Service,
 
-	eventsReader events.EventReader,
+	eventsReader *events.Subscriber,
 
 	userRootResover *resolvers.UserRootResolver,
 	workspaceRootResolver *resolvers.WorkspaceRootResolver,

--- a/api/pkg/workspaces/watchers/service/module.go
+++ b/api/pkg/workspaces/watchers/service/module.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"getsturdy.com/api/pkg/di"
-	"getsturdy.com/api/pkg/events"
+	"getsturdy.com/api/pkg/events/v2"
+	"getsturdy.com/api/pkg/logger"
 	db_watchers "getsturdy.com/api/pkg/workspaces/watchers/db"
 )
 
 func Module(c *di.Container) {
 	c.Import(db_watchers.Module)
 	c.Import(events.Module)
+	c.Import(logger.Module)
 	c.Register(New)
 }


### PR DESCRIPTION
<p>api/events: move workspace watcher event to v2</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/df07c3a5-d4b6-4df6-8a12-22c39156aa39).

Update this PR by making changes through Sturdy.
