### PR TITLE
api/pkg/snapshots: accept a context

### DIFF
--- a/api/pkg/changes/service/land.go
+++ b/api/pkg/changes/service/land.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 )
 
 func (s *Service) CreateAndLandFromView(
+	ctx context.Context,
 	viewRepo vcs.RepoWriter,
 	codebaseID codebases.ID,
 	workspaceID string,
@@ -27,7 +29,7 @@ func (s *Service) CreateAndLandFromView(
 		return "", nil, fmt.Errorf("can not create on a non view")
 	}
 
-	snapshot, err := s.snap.Snapshot(codebaseID, workspaceID, snapshots.ActionPreChangeLand, service_snapshots.WithOnRepo(viewRepo), service_snapshots.WithOnView(*viewID))
+	snapshot, err := s.snap.Snapshot(ctx, codebaseID, workspaceID, snapshots.ActionPreChangeLand, service_snapshots.WithOnRepo(viewRepo), service_snapshots.WithOnView(*viewID))
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to snapshot: %w", err)
 	}
@@ -52,7 +54,7 @@ func (s *Service) CreateAndLandFromView(
 		s.logger.Info("successfully restored view after failed landing")
 	}()
 
-	createdCommitID, err := vcs_changes.CreateChangeFromPatchesOnRepo(s.logger, viewRepo, codebaseID, nil, message, signature, diffOpts...)
+	createdCommitID, err := vcs_changes.CreateChangeFromPatchesOnRepo(ctx, s.logger, viewRepo, codebaseID, nil, message, signature, diffOpts...)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create the new change: %w", err)
 	}

--- a/api/pkg/changes/vcs/vcs_test.go
+++ b/api/pkg/changes/vcs/vcs_test.go
@@ -1,6 +1,7 @@
 package vcs_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -58,7 +59,7 @@ func TestAddModifyDeleteBinaryFile(t *testing.T) {
 	diffs := getDiffs(t, repo)
 	assert.Len(t, diffs, 2)
 
-	_, err = vcs_change.CreateChangeFromPatchesOnRepo(zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "adding binary files", sig)
+	_, err = vcs_change.CreateChangeFromPatchesOnRepo(context.Background(), zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "adding binary files", sig)
 	assert.NoError(t, err)
 
 	// Expect empty diff
@@ -72,7 +73,7 @@ func TestAddModifyDeleteBinaryFile(t *testing.T) {
 	diffs = getDiffs(t, repo)
 	assert.Len(t, diffs, 2)
 
-	_, err = vcs_change.CreateChangeFromPatchesOnRepo(zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "modify binary files", sig)
+	_, err = vcs_change.CreateChangeFromPatchesOnRepo(context.Background(), zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "modify binary files", sig)
 	assert.NoError(t, err)
 
 	// Expect empty diff
@@ -86,7 +87,7 @@ func TestAddModifyDeleteBinaryFile(t *testing.T) {
 	diffs = getDiffs(t, repo)
 	assert.Len(t, diffs, 2)
 
-	_, err = vcs_change.CreateChangeFromPatchesOnRepo(zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "remove binary files", sig)
+	_, err = vcs_change.CreateChangeFromPatchesOnRepo(context.Background(), zap.NewNop(), repo, codebaseID, allHunkIDs(diffs), "remove binary files", sig)
 	assert.NoError(t, err)
 
 	// Expect empty diff
@@ -265,7 +266,7 @@ func TestStagedCleanup(t *testing.T) {
 	assert.Len(t, hunkIds, 2)
 
 	// This should work! Even if we're trying to add an already added file.
-	_, err = vcs_change.CreateChangeFromPatchesOnRepo(zap.NewNop(), r, codebaseID, hunkIds, "added all", sig)
+	_, err = vcs_change.CreateChangeFromPatchesOnRepo(context.Background(), zap.NewNop(), r, codebaseID, hunkIds, "added all", sig)
 	assert.NoError(t, err)
 
 	// Test that it's safe to run CleanStaged even if the "staging area" is empty

--- a/api/pkg/comments/vcs/context_test.go
+++ b/api/pkg/comments/vcs/context_test.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -195,7 +196,7 @@ func TestContext(t *testing.T) {
 		t.Run(fmt.Sprintf("%d-%v", tc.lineNumber, tc.lineIsNew), func(t *testing.T) {
 			if tc.useSnapshot {
 				// make a snapshot
-				snapshot, err := d.GitSnapshotter.Snapshot(codebaseID, workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(viewID), service_snapshots.WithNoThrottle())
+				snapshot, err := d.GitSnapshotter.Snapshot(context.Background(), codebaseID, workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(viewID), service_snapshots.WithNoThrottle())
 				if assert.NoError(t, err) && assert.NotNil(t, snapshot) {
 					ws.LatestSnapshotID = &snapshot.ID
 				}

--- a/api/pkg/github/enterprise/graphql/codebase_github_integration_import.go
+++ b/api/pkg/github/enterprise/graphql/codebase_github_integration_import.go
@@ -116,7 +116,7 @@ func (r *codebaseGitHubIntegrationRootResolver) CreateWorkspaceFromGitHubBranch(
 			}
 
 			// Create a snapshot
-			if _, err := r.snapshotter.Snapshot(codebaseID, workspaceID, snapshots.ActionSyncCompleted,
+			if _, err := r.snapshotter.Snapshot(ctx, codebaseID, workspaceID, snapshots.ActionSyncCompleted,
 				service_snapshotter.WithOnView(viewID),
 				service_snapshotter.WithMarkAsLatestInWorkspace(),
 			); err != nil {

--- a/api/pkg/github/enterprise/service/service_import.go
+++ b/api/pkg/github/enterprise/service/service_import.go
@@ -128,6 +128,9 @@ func (svc *Service) fetchAndSnapshotPullRequest(
 	importBranchName := fmt.Sprintf("import-pull-request-%d-%s", gitHubPR.GetNumber(), uuid.NewString())
 	refspec := fmt.Sprintf("+refs/pull/%d/head:refs/heads/%s", gitHubPR.GetNumber(), importBranchName)
 
+	ctx, cancelTimeout := context.WithTimeout(context.Background(), time.Minute*2)
+	defer cancelTimeout()
+
 	var commonAncestor string
 
 	// Fetch to trunk
@@ -180,7 +183,8 @@ func (svc *Service) fetchAndSnapshotPullRequest(
 				return fmt.Errorf("failed to reset temporary view to common ancestor: %w", err)
 			}
 
-			if _, err := svc.snap.Snapshot(workspace.CodebaseID, workspace.ID,
+			if _, err := svc.snap.Snapshot(ctx,
+				workspace.CodebaseID, workspace.ID,
 				snapshots.ActionImported,
 				service_snapshots.WithMarkAsLatestInWorkspace(),
 				service_snapshots.WithOnView(*repo.ViewID()),

--- a/api/pkg/github/enterprise/service/service_import_test.go
+++ b/api/pkg/github/enterprise/service/service_import_test.go
@@ -192,7 +192,7 @@ func TestService_ImportPullRequest(t *testing.T) {
 	t.Run("ImportPullRequest", func(t *testing.T) {
 		pr, _ := createFakePr(5000, 1, "foobar.txt", "hello world")
 
-		err = d.GitHubService.ImportPullRequest(usr.ID, pr, repo, installation, "testing-access-token")
+		err = d.GitHubService.ImportPullRequest(context.Background(), usr.ID, pr, repo, installation, "testing-access-token")
 		assert.NoError(t, err)
 
 		ws := getWorkspace("<p>hello world</p>")

--- a/api/pkg/land/enterprise/graphql/graphql.go
+++ b/api/pkg/land/enterprise/graphql/graphql.go
@@ -86,7 +86,7 @@ func (r *LandRootResolver) PushWorkspace(ctx context.Context, args resolvers.Pus
 			return nil, gqlerrors.Error(err)
 		}
 
-		if err := r.landService.Push(ctx, user, ws); err != nil {
+		if err := r.landService.Push(context.Background(), user, ws); err != nil {
 			return nil, gqlerrors.Error(err)
 		}
 	}

--- a/api/pkg/land/service/service.go
+++ b/api/pkg/land/service/service.go
@@ -116,6 +116,7 @@ func (s *Service) LandChange(ctx context.Context, ws *workspaces.Workspace, diff
 	var change *changes.Change
 	creteAndLand := func(viewRepo vcs.RepoWriter) error {
 		createdCommitID, fromViewPushFunc, err := s.changeService.CreateAndLandFromView(
+			context.Background(),
 			viewRepo,
 			ws.CodebaseID,
 			ws.ID,

--- a/api/pkg/remote/enterprise/service/service.go
+++ b/api/pkg/remote/enterprise/service/service.go
@@ -342,7 +342,7 @@ func (svc *EnterpriseService) PrepareBranchForPush(ctx context.Context, prBranch
 		}
 		return
 	} else if ws.ViewID != nil {
-		commitSha, err = svc.prepareBranchForPullRequestWithView(prBranchName, ws, commitMessage, userName, userEmail)
+		commitSha, err = svc.prepareBranchForPullRequestWithView(ctx, prBranchName, ws, commitMessage, userName, userEmail)
 		if err != nil {
 			return "", fmt.Errorf("failed to prepare branch from snapshot: %w", err)
 		}
@@ -383,7 +383,7 @@ func (svc *EnterpriseService) prepareBranchForPullRequestFromSnapshot(ctx contex
 	return resSha, nil
 }
 
-func (svc *EnterpriseService) prepareBranchForPullRequestWithView(prBranchName string, ws *workspaces.Workspace, commitMessage, userName, userEmail string) (string, error) {
+func (svc *EnterpriseService) prepareBranchForPullRequestWithView(ctx context.Context, prBranchName string, ws *workspaces.Workspace, commitMessage, userName, userEmail string) (string, error) {
 	signature := git.Signature{
 		Name:  userName,
 		Email: userEmail,
@@ -393,7 +393,7 @@ func (svc *EnterpriseService) prepareBranchForPullRequestWithView(prBranchName s
 	var resSha string
 
 	exec := svc.executorProvider.New().FileReadGitWrite(func(r vcs.RepoReaderGitWriter) error {
-		treeID, err := vcs_change.CreateChangesTreeFromPatches(svc.logger, r, ws.CodebaseID, nil)
+		treeID, err := vcs_change.CreateChangesTreeFromPatches(ctx, svc.logger, r, ws.CodebaseID, nil)
 		if err != nil {
 			return err
 		}

--- a/api/pkg/snapshots/service/service.go
+++ b/api/pkg/snapshots/service/service.go
@@ -191,7 +191,7 @@ func (s *Service) Delete(ctx context.Context, snapshot *snapshots.Snapshot) erro
 }
 
 //nolint:cyclop
-func (s *Service) Snapshot(codebaseID codebases.ID, workspaceID string, action snapshots.Action, opts ...SnapshotOption) (*snapshots.Snapshot, error) {
+func (s *Service) Snapshot(ctx context.Context, codebaseID codebases.ID, workspaceID string, action snapshots.Action, opts ...SnapshotOption) (*snapshots.Snapshot, error) {
 	options := getSnapshotOptions(opts...)
 
 	if !options.onTemporaryView && options.onView == nil {
@@ -363,7 +363,7 @@ func (s *Service) Snapshot(codebaseID codebases.ID, workspaceID string, action s
 		}
 
 		var err error
-		snapshotCommitSHA, err = vcs_snapshots.SnapshotOnViewRepo(s.logger, options.onRepo, codebaseID, snapshotID, gitSignature, snapshotOptions...)
+		snapshotCommitSHA, err = vcs_snapshots.SnapshotOnViewRepo(ctx, s.logger, options.onRepo, codebaseID, snapshotID, gitSignature, snapshotOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func (s *Service) Snapshot(codebaseID codebases.ID, workspaceID string, action s
 			// Normal snapshot
 			exec = exec.Read(countDiffs)
 			exec = exec.FileReadGitWrite(func(repo vcs.RepoReaderGitWriter) error {
-				commitID, err := vcs_snapshots.SnapshotOnViewRepo(s.logger, repo, codebaseID, snapshotID, gitSignature, snapshotOptions...)
+				commitID, err := vcs_snapshots.SnapshotOnViewRepo(ctx, s.logger, repo, codebaseID, snapshotID, gitSignature, snapshotOptions...)
 				if err != nil {
 					return err
 				}
@@ -702,7 +702,7 @@ func (s *Service) Copy(ctx context.Context, snapshotID snapshots.ID, oo ...CopyO
 				return fmt.Errorf("failed to apply patches to workdir: %w", err)
 			}
 
-			commitID, err := vcs_snapshots.SnapshotOnViewRepo(s.logger, repo, newSnapshot.CodebaseID, newSnapshot.ID, gitSignature)
+			commitID, err := vcs_snapshots.SnapshotOnViewRepo(ctx, s.logger, repo, newSnapshot.CodebaseID, newSnapshot.ID, gitSignature)
 			if err != nil {
 				return fmt.Errorf("failed to snapshot on view repo: %w", err)
 			}

--- a/api/pkg/snapshots/service/service_test.go
+++ b/api/pkg/snapshots/service/service_test.go
@@ -101,10 +101,10 @@ func setup(t *testing.T) *testCase {
 func TestSnapshot_noChanges(t *testing.T) {
 	tc := setup(t)
 
-	snapOnce, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapOnce, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
-	snapTwice, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapTwice, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.Equal(t, snapOnce.ID, snapTwice.ID, "snapshots must be identical, no changes were made")
@@ -113,12 +113,12 @@ func TestSnapshot_noChanges(t *testing.T) {
 func TestSnapshot_noChangesDeleted(t *testing.T) {
 	tc := setup(t)
 
-	snapOnce, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapOnce, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.NoError(t, tc.snapshotService.Delete(context.Background(), snapOnce))
 
-	snapTwice, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapTwice, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, snapOnce.ID, snapTwice.ID, "snapshots must not be identical, the first one was removed")
@@ -127,18 +127,18 @@ func TestSnapshot_noChangesDeleted(t *testing.T) {
 func TestSnapshot_previous_next(t *testing.T) {
 	tc := setup(t)
 
-	snapOnce, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
+	snapOnce, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.NoError(t, tc.executorProvider.New().Write(writeFile("test.txt", []byte("test"))).ExecView(tc.codebaseID, tc.viewID, "make some changes"))
 
-	snapTwice, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
+	snapTwice, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 	assert.NotEqual(t, snapOnce.ID, snapTwice.ID, "snapshots must not be identical, changes were made")
 
 	assert.NoError(t, tc.executorProvider.New().Write(writeFile("test.txt", []byte("test2"))).ExecView(tc.codebaseID, tc.viewID, "make some changes"))
 
-	snapTri, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
+	snapTri, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.Action("test"), service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 	assert.NotEqual(t, snapTwice.ID, snapTri.ID, "snapshots must not be identical, changes were made")
 
@@ -172,12 +172,12 @@ func TestSnapshot_previous_next(t *testing.T) {
 func TestSnapshot_changes(t *testing.T) {
 	tc := setup(t)
 
-	snapOnce, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapOnce, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.NoError(t, tc.executorProvider.New().Write(writeFile("test.txt", []byte("test"))).ExecView(tc.codebaseID, tc.viewID, "make some changes"))
 
-	snapTwice, err := tc.snapshotService.Snapshot(tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
+	snapTwice, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, tc.workspaceID, snapshots.ActionViewSync, service_snapshots.WithOnView(tc.viewID))
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, snapOnce.ID, snapTwice.ID, "snapshots must not be identical, changes were made")

--- a/api/pkg/snapshots/vcs/snapshots.go
+++ b/api/pkg/snapshots/vcs/snapshots.go
@@ -1,6 +1,7 @@
 package vcs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -82,7 +83,7 @@ func allPatchIDs(logger *zap.Logger, repo vcs.RepoGitReader) ([]string, error) {
 	return patchIDs, nil
 }
 
-func SnapshotOnViewRepo(logger *zap.Logger, repo vcs.RepoReaderGitWriter, codebaseID codebases.ID, snapshotID snapshots.ID, signature git.Signature, opts ...SnapshotOption) (string, error) {
+func SnapshotOnViewRepo(ctx context.Context, logger *zap.Logger, repo vcs.RepoReaderGitWriter, codebaseID codebases.ID, snapshotID snapshots.ID, signature git.Signature, opts ...SnapshotOption) (string, error) {
 	start := time.Now()
 
 	options := snapshotOptions(opts...)
@@ -124,7 +125,7 @@ func SnapshotOnViewRepo(logger *zap.Logger, repo vcs.RepoReaderGitWriter, codeba
 	if len(patchIDs) == 0 {
 		snapshotCommitID, err = repo.AddAndCommitWithSignature(commitMessage, signature)
 	} else {
-		snapshotCommitID, err = vcs_change.CreateChangeFromPatchesOnRepo(decoratedLogger, repo, codebaseID, patchIDs, commitMessage, signature)
+		snapshotCommitID, err = vcs_change.CreateChangeFromPatchesOnRepo(ctx, decoratedLogger, repo, codebaseID, patchIDs, commitMessage, signature)
 	}
 	if err != nil {
 		return "", fmt.Errorf("failed to make snapshot: %w", err)

--- a/api/pkg/snapshots/worker/mock.go
+++ b/api/pkg/snapshots/worker/mock.go
@@ -31,7 +31,7 @@ func (p *inProcessPublisher) Enqueue(ctx context.Context, codebaseID codebases.I
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)
 	}
-	_, err = p.snapshotter.Snapshot(codebaseID, workspaceID, action, service_snapshots.WithOnView(viewID), service_snapshots.WithUser(user))
+	_, err = p.snapshotter.Snapshot(ctx, codebaseID, workspaceID, action, service_snapshots.WithOnView(viewID), service_snapshots.WithUser(user))
 	if err != nil {
 		return err
 	}

--- a/api/pkg/suggestions/service/service.go
+++ b/api/pkg/suggestions/service/service.go
@@ -251,6 +251,7 @@ func (s *Service) ApplyHunks(ctx context.Context, suggestion *suggestions.Sugges
 				}
 
 				if _, err := s.snapshotter.Snapshot(
+					ctx,
 					originalWorkspace.CodebaseID,
 					originalWorkspace.ID,
 					snapshots.ActionSuggestionApply,
@@ -361,6 +362,7 @@ func (s *Service) RemovePatches(ctx context.Context, suggestion *suggestions.Sug
 				return err
 			}
 			if _, err := s.snapshotter.Snapshot(
+				ctx,
 				workspace.CodebaseID,
 				workspace.ID,
 				snapshots.ActionFileUndoPatch,
@@ -389,6 +391,7 @@ func (s *Service) RemovePatches(ctx context.Context, suggestion *suggestions.Sug
 					return err
 				}
 				if _, err := s.snapshotter.Snapshot(
+					ctx,
 					workspace.CodebaseID,
 					workspace.ID,
 					snapshots.ActionFileUndoPatch,

--- a/api/pkg/suggestions/service/service_test.go
+++ b/api/pkg/suggestions/service/service_test.go
@@ -130,14 +130,14 @@ func (o *operation) validate(t *testing.T, test *test) {
 }
 
 func (o *operation) snapshotSuggesting(t *testing.T, test *test) {
-	suggestingSnapshot, err := test.gitSnapshotter.Snapshot(test.codebaseID, test.suggestingWorkspace.ID, snapshots.ActionViewSync, service_snapshots.WithOnView(test.suggestingViewID))
+	suggestingSnapshot, err := test.gitSnapshotter.Snapshot(context.Background(), test.codebaseID, test.suggestingWorkspace.ID, snapshots.ActionViewSync, service_snapshots.WithOnView(test.suggestingViewID))
 	assert.NoError(t, err)
 	test.suggestingWorkspace.LatestSnapshotID = &suggestingSnapshot.ID
 	assert.NoError(t, test.workspaceDB.UpdateFields(context.TODO(), test.suggestingWorkspace.ID, db_workspaces.SetLatestSnapshotID(&suggestingSnapshot.ID)))
 }
 
 func (o *operation) snapshotOriginal(t *testing.T, test *test) {
-	snapshot, err := test.gitSnapshotter.Snapshot(test.codebaseID, test.originalWorkspace.ID, snapshots.ActionSuggestionApply, service_snapshots.WithOnView(test.originalViewID))
+	snapshot, err := test.gitSnapshotter.Snapshot(context.Background(), test.codebaseID, test.originalWorkspace.ID, snapshots.ActionSuggestionApply, service_snapshots.WithOnView(test.originalViewID))
 	assert.NoError(t, err)
 	test.originalWorkspace.LatestSnapshotID = &snapshot.ID
 	assert.NoError(t, test.workspaceDB.UpdateFields(context.TODO(), test.originalWorkspace.ID, db_workspaces.SetLatestSnapshotID(&snapshot.ID)))

--- a/api/pkg/sync/service/service.go
+++ b/api/pkg/sync/service/service.go
@@ -106,7 +106,7 @@ func (svc *Service) OnTrunk(ctx context.Context, ws *workspaces.Workspace) (*syn
 			return fmt.Errorf("failed to log changed files before sync: %w", err)
 		}
 
-		treeID, err := change_vcs.CreateChangesTreeFromPatches(svc.logger, repo, ws.CodebaseID, nil)
+		treeID, err := change_vcs.CreateChangesTreeFromPatches(ctx, svc.logger, repo, ws.CodebaseID, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create tree from patches during sync: %w", err)
 		}
@@ -265,7 +265,7 @@ func (svc *Service) complete(ctx context.Context, repo vcsvcs.RepoWriter, codeba
 	// Make a snapshot (right away)
 	// The "conflict" status is calculated based on the latest snapshot of a workspace
 	// Create a snapshot right away to re-calculate the conflicting status
-	if _, err := svc.snap.Snapshot(codebaseID, workspaceID, snapshots.ActionSyncCompleted,
+	if _, err := svc.snap.Snapshot(ctx, codebaseID, workspaceID, snapshots.ActionSyncCompleted,
 		service_snapshots.WithOnView(viewID),
 		service_snapshots.WithOnRepo(repo),
 		service_snapshots.WithMarkAsLatestInWorkspace(),

--- a/api/pkg/unidiff/unidiff_test.go
+++ b/api/pkg/unidiff/unidiff_test.go
@@ -1,6 +1,7 @@
 package unidiff
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -426,7 +427,7 @@ func TestFilterAndApply(t *testing.T) {
 			}
 
 			// Test that all patches can be applied together
-			_, err = viewRepo.ApplyPatchesToIndex(allPatches)
+			_, err = viewRepo.ApplyPatchesToIndex(context.Background(), allPatches)
 			assert.NoError(t, err)
 		})
 	}

--- a/api/pkg/view/graphql/viewResolver.go
+++ b/api/pkg/view/graphql/viewResolver.go
@@ -261,7 +261,7 @@ func (r *ViewRootResolver) RepairView(ctx context.Context, args struct{ ID graph
 			restoreWs = ws
 		}
 
-		if err := recreateView(repoProvider, vw, restoreWs, r.logger, r.snapshotter); err != nil {
+		if err := recreateView(ctx, repoProvider, vw, restoreWs, r.logger, r.snapshotter); err != nil {
 			return err
 		}
 		return nil
@@ -307,7 +307,7 @@ func (r *ViewRootResolver) CreateView(ctx context.Context, args resolvers.Create
 	}
 }
 
-func recreateView(repoProvider provider.RepoProvider, vw *view.View, ws *workspaces.Workspace, logger *zap.Logger, gitSnapshotter *service_snapshots.Service) error {
+func recreateView(ctx context.Context, repoProvider provider.RepoProvider, vw *view.View, ws *workspaces.Workspace, logger *zap.Logger, gitSnapshotter *service_snapshots.Service) error {
 	trunkPath := repoProvider.TrunkPath(vw.CodebaseID)
 	newView := vw.ID + "-recreate-" + uuid.NewString()
 	newViewPath := repoProvider.ViewPath(vw.CodebaseID, newView)
@@ -327,7 +327,7 @@ func recreateView(repoProvider provider.RepoProvider, vw *view.View, ws *workspa
 		}
 
 		// Attempt to make a snapshot of the existing view
-		snapshot, err := gitSnapshotter.Snapshot(vw.CodebaseID, vw.WorkspaceID, snapshots.ActionPreCheckoutOtherView, service_snapshots.WithOnView(vw.ID))
+		snapshot, err := gitSnapshotter.Snapshot(ctx, vw.CodebaseID, vw.WorkspaceID, snapshots.ActionPreCheckoutOtherView, service_snapshots.WithOnView(vw.ID))
 		if err != nil {
 			return err
 		}

--- a/api/pkg/view/service/service.go
+++ b/api/pkg/view/service/service.go
@@ -80,7 +80,7 @@ func (s *Service) OpenWorkspace(ctx context.Context, view *view.View, ws *worksp
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("could not find previous workspace on view: %w", err)
 	} else if err == nil {
-		_, err := s.gitSnapshotter.Snapshot(currentWorkspaceOnView.CodebaseID, currentWorkspaceOnView.ID,
+		_, err := s.gitSnapshotter.Snapshot(ctx, currentWorkspaceOnView.CodebaseID, currentWorkspaceOnView.ID,
 			snapshots.ActionPreCheckoutOtherWorkspace, service_snapshots.WithOnView(*currentWorkspaceOnView.ViewID), service_snapshots.WithMarkAsLatestInWorkspace())
 		if errors.Is(err, service_snapshots.ErrCantSnapshotRebasing) {
 			return ErrRebasing
@@ -98,7 +98,7 @@ func (s *Service) OpenWorkspace(ctx context.Context, view *view.View, ws *worksp
 	// If the workspace that we're opening on the view, currently is opened somewhere else, snapshot it and save the changes
 	// The snapshot will also be used to "move" the contents to the new view
 	if ws.ViewID != nil {
-		_, err := s.gitSnapshotter.Snapshot(ws.CodebaseID, ws.ID, snapshots.ActionPreCheckoutOtherView,
+		_, err := s.gitSnapshotter.Snapshot(ctx, ws.CodebaseID, ws.ID, snapshots.ActionPreCheckoutOtherView,
 			service_snapshots.WithOnView(*ws.ViewID), service_snapshots.WithMarkAsLatestInWorkspace())
 		if err != nil {
 			return fmt.Errorf("failed to snapshot: %w", err)

--- a/api/pkg/workspaces/service/service.go
+++ b/api/pkg/workspaces/service/service.go
@@ -268,7 +268,7 @@ func (s *Service) CopyPatches(ctx context.Context, dist, src *workspaces.Workspa
 		if options.PatchIDs != nil {
 			snapshotterOptions = append(snapshotterOptions, service_snapshots.WithPatchIDsFilter(*options.PatchIDs))
 		}
-		snapshot, err := s.snap.Snapshot(src.CodebaseID, src.ID, snapshots.ActionWorkspaceExtract, snapshotterOptions...)
+		snapshot, err := s.snap.Snapshot(ctx, src.CodebaseID, src.ID, snapshots.ActionWorkspaceExtract, snapshotterOptions...)
 		if err != nil {
 			return fmt.Errorf("failed to create snapshot: %w", err)
 		}
@@ -406,6 +406,7 @@ func (s *Service) Create(ctx context.Context, req CreateWorkspaceRequest) (*work
 	// Add the reverted changes to a snapshot
 	if req.BaseChangeID != nil && baseCommitSha != "" && req.Revert {
 		if _, err := s.snap.Snapshot(
+			ctx,
 			ws.CodebaseID,
 			ws.ID,
 			snapshots.ActionChangeReverted,
@@ -557,6 +558,7 @@ func (svc *Service) CreateWelcomeWorkspace(ctx context.Context, codebaseID codeb
 		}
 
 		if _, err := svc.snap.Snapshot(
+			ctx,
 			codebaseID, ws.ID,
 			snapshots.ActionViewSync, // TODO: Dedicated action for this?
 			service_snapshots.WithOnTemporaryView(),
@@ -610,6 +612,7 @@ func (s *Service) RemovePatches(ctx context.Context, ws *workspaces.Workspace, h
 				}
 
 				if _, err := s.snap.Snapshot(
+					ctx,
 					ws.CodebaseID,
 					ws.ID,
 					snapshots.ActionFileUndoPatch,

--- a/api/pkg/workspaces/service/service_test.go
+++ b/api/pkg/workspaces/service/service_test.go
@@ -129,12 +129,12 @@ func TestWorkspace_SetSnapshot(t *testing.T) {
 
 	assert.NoError(t, tc.executorProvider.New().Write(writeFile("test.txt", []byte("test"))).ExecView(tc.codebaseID, vw.ID, "make some changes"))
 
-	firstSnapshot, err := tc.snapshotService.Snapshot(tc.codebaseID, ws.ID, snapshots.Action("testing"), service_snapshots.WithOnView(vw.ID))
+	firstSnapshot, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, ws.ID, snapshots.Action("testing"), service_snapshots.WithOnView(vw.ID))
 	assert.NoError(t, err)
 
 	assert.NoError(t, tc.executorProvider.New().Write(writeFile("test.txt", []byte("test2"))).ExecView(tc.codebaseID, vw.ID, "make more changes"))
 
-	secondSnapshot, err := tc.snapshotService.Snapshot(tc.codebaseID, ws.ID, snapshots.Action("testing"), service_snapshots.WithOnView(vw.ID))
+	secondSnapshot, err := tc.snapshotService.Snapshot(context.Background(), tc.codebaseID, ws.ID, snapshots.Action("testing"), service_snapshots.WithOnView(vw.ID))
 	assert.NoError(t, err)
 	assert.Equal(t, firstSnapshot.ID, *secondSnapshot.PreviousSnapshotID)
 

--- a/api/vcs/repository.go
+++ b/api/vcs/repository.go
@@ -1,6 +1,8 @@
 package vcs
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	git "github.com/libgit2/git2go/v33"
@@ -87,7 +89,7 @@ type RepoGitWriter interface {
 	MergeBranches(ourBranchName, theirBranchName string) (*git.Index, error)
 	MergeBranchInto(branchName, mergeIntoBranchName string) (mergeCommitId string, err error)
 
-	ApplyPatchesToIndex(patches [][]byte) (*git.Oid, error)
+	ApplyPatchesToIndex(ctx context.Context, patches [][]byte) (*git.Oid, error)
 }
 
 type RepoReaderGitWriter interface {


### PR DESCRIPTION
<p>api/pkg/snapshots: accept a context</p><p>Add a 2 minute timeout for creating snapshots, both when triggered from view syncing and when importing PRs.</p>

---

This PR was created by Gustav Westling (zegl) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/4415fa6d-3396-4654-aa58-61663981eb6d).

Update this PR by making changes through Sturdy.
