### PR TITLE
api/snapshots: do not fail when commit not found

### DIFF
--- a/api/pkg/snapshots/service/service.go
+++ b/api/pkg/snapshots/service/service.go
@@ -277,7 +277,9 @@ func (s *Service) Snapshot(ctx context.Context, codebaseID codebases.ID, workspa
 			}
 
 			previousCommit, err := repo.Commit(latest.CommitSHA)
-			if err != nil {
+			if errors.Is(err, vcs.ErrNotFound) {
+				return nil
+			} else if err != nil {
 				return fmt.Errorf("can't get previous commit %s: %w", latest.CommitSHA, err)
 			}
 

--- a/api/vcs/git.go
+++ b/api/vcs/git.go
@@ -867,7 +867,15 @@ func (r *repository) Commit(sha string) (*git.Commit, error) {
 		return nil, fmt.Errorf("failed to create oid: %w", err)
 	}
 
-	return r.r.LookupCommit(oid)
+	commit, err := r.r.LookupCommit(oid)
+	if err != nil {
+		//nolint:errorlint
+		if gErr, ok := err.(*git.GitError); ok && gErr.Code == git.ErrorCodeNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return commit, nil
 }
 
 func (r *repository) HeadCommit() (*git.Commit, error) {


### PR DESCRIPTION
<p>api/snapshots: do not fail when commit not found</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/3f32807d-5e6a-42bb-8bc0-cda5cd60f8a5).

Update this PR by making changes through Sturdy.
