### PR TITLE
web/workspace: do not display description for suggesting workspaces

### DIFF
--- a/web/src/pages/WorkspaceHome.vue
+++ b/web/src/pages/WorkspaceHome.vue
@@ -181,6 +181,7 @@
             </div>
 
             <WorkspaceDescription
+              v-if="!isSuggesting"
               class="max-w-prose"
               :workspace="data.workspace"
               :user="user"


### PR DESCRIPTION
<p>web/workspace: do not display description for suggesting workspaces</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/e9f413bb-e3e8-436e-8508-995cfc8c7c3d).

Update this PR by making changes through Sturdy.
