### PR TITLE
api/comments: allow only members of the codebase resolve comments

### DIFF
--- a/api/pkg/comments/graphql/resolver.go
+++ b/api/pkg/comments/graphql/resolver.go
@@ -15,6 +15,7 @@ import (
 	"getsturdy.com/api/pkg/changes"
 	service_change "getsturdy.com/api/pkg/changes/service"
 	"getsturdy.com/api/pkg/codebases"
+	"getsturdy.com/api/pkg/codebases/access"
 	db_codebases "getsturdy.com/api/pkg/codebases/db"
 	"getsturdy.com/api/pkg/comments"
 	db_comments "getsturdy.com/api/pkg/comments/db"
@@ -389,8 +390,8 @@ func (r *CommentRootResolver) ResolveComment(ctx context.Context, args resolvers
 
 	}
 
-	if err := r.authService.CanRead(ctx, comm); err != nil {
-		return nil, gqlerrors.Error(err)
+	if !access.UserHasAccessToCodebase(r.codebaseUserRepo, userID, comm.CodebaseID) {
+		return nil, fmt.Errorf("user %s is not a part of codebase %s: %w", userID, comm.CodebaseID, auth.ErrForbidden)
 	}
 
 	r.analyticsService.Capture(ctx, "resolved comment",


### PR DESCRIPTION
<p>api/comments: allow only members of the codebase resolve comments</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/dd41833f-cda2-4e1b-aba7-03ac55691353).

Update this PR by making changes through Sturdy.
