### PR TITLE
api/queue: ensure inmemory implementation is exactly once fifo

### DIFF
--- a/api/pkg/github/enterprise/service/pull_request_test.go
+++ b/api/pkg/github/enterprise/service/pull_request_test.go
@@ -142,6 +142,9 @@ func TestPRHighLevel(t *testing.T) {
 	go func() {
 		assert.NoError(t, d.WebhooksQueue.Start(context.TODO()))
 	}()
+	go func() {
+		assert.NoError(t, d.BuildQueue.Start(context.TODO()))
+	}()
 
 	testCases := []struct {
 		name                       string

--- a/api/pkg/queue/inmemory.go
+++ b/api/pkg/queue/inmemory.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"getsturdy.com/api/pkg/queue/names"
-	"golang.org/x/sync/errgroup"
 
 	"go.uber.org/zap"
 )
@@ -18,13 +18,18 @@ type InMemoryQueue struct {
 	logger     *zap.Logger
 	sync       bool
 	chansGuard sync.RWMutex
-	chans      map[names.IncompleteQueueName][]chan<- Message
+	chans      map[names.IncompleteQueueName]chan Message
+
+	bufferSize int
+	timeout    time.Duration
 }
 
 func NewInMemory(logger *zap.Logger) *InMemoryQueue {
 	return &InMemoryQueue{
-		logger: logger,
-		chans:  make(map[names.IncompleteQueueName][]chan<- Message),
+		logger:     logger.Named("inmemory queue"),
+		chans:      make(map[names.IncompleteQueueName]chan Message),
+		bufferSize: 10,
+		timeout:    time.Second,
 	}
 }
 
@@ -62,37 +67,56 @@ func (m *inmemorymessage) As(v any) error {
 	return json.Unmarshal(m.marshalledMessage, v)
 }
 
-func (q *InMemoryQueue) Publish(ctx context.Context, name names.IncompleteQueueName, msg any) error {
+func (q *InMemoryQueue) getChannel(name names.IncompleteQueueName) chan Message {
 	q.chansGuard.RLock()
-	defer q.chansGuard.RUnlock()
-	chans, ok := q.chans[name]
-	if !ok {
-		return nil
+	ch, found := q.chans[name]
+	q.chansGuard.RUnlock()
+	if found {
+		return ch
+	}
+	q.chansGuard.Lock()
+	ch = make(chan Message, q.bufferSize)
+	q.chans[name] = ch
+	q.chansGuard.Unlock()
+	return ch
+}
+
+func (q *InMemoryQueue) Publish(ctx context.Context, name names.IncompleteQueueName, msg any) error {
+	q.logger.Info("publishing message", zap.String("queue", name.String()))
+
+	ch := q.getChannel(name)
+	m, err := newInmemoryMessage(msg)
+	if err != nil {
+		return fmt.Errorf("failed to create message: %w", err)
 	}
 
-	wg, _ := errgroup.WithContext(ctx)
-	for _, ch := range chans {
-		ch := ch
-		wg.Go(func() error {
-			m, err := newInmemoryMessage(msg)
-			if err != nil {
-				return fmt.Errorf("failed to create message: %w", err)
-			}
-			ch <- m
-			if q.sync {
-				m.AwaitAcked()
-			}
-			return nil
-		})
+	select {
+	case ch <- m:
+		if q.sync {
+
+			fmt.Printf("\nnikitag: %+v\n\n", name.String())
+
+			m.AwaitAcked()
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(q.timeout):
+		return fmt.Errorf("failed to publish message: queue is full")
 	}
-	return wg.Wait()
 }
 
 func (q *InMemoryQueue) Subscribe(ctx context.Context, name names.IncompleteQueueName, messages chan<- Message) error {
-	q.chansGuard.Lock()
-	q.chans[name] = append(q.chans[name], messages)
-	q.chansGuard.Unlock()
+	q.logger.Info("subscribing to queue", zap.String("queue", name.String()))
+	ch := q.getChannel(name)
 
-	<-ctx.Done()
-	return nil
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case m := <-ch:
+			q.logger.Info("received message", zap.String("queue", name.String()))
+			messages <- m
+		}
+	}
 }

--- a/api/pkg/queue/inmemory_test.go
+++ b/api/pkg/queue/inmemory_test.go
@@ -1,0 +1,73 @@
+package queue
+
+import (
+	"context"
+	"testing"
+
+	"getsturdy.com/api/pkg/logger"
+	"getsturdy.com/api/pkg/queue/names"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInmemory__once(t *testing.T) {
+	q := NewInMemory(logger.NewTest(t))
+	name := names.IncompleteQueueName("testing")
+
+	msgs := make(chan Message)
+	go func() { // consumer 1
+		assert.NoError(t, q.Subscribe(context.TODO(), name, msgs))
+	}()
+	go func() { // consumer 2
+		assert.NoError(t, q.Subscribe(context.TODO(), name, msgs))
+	}()
+	go func() { // producer
+		for i := 0; i < 10; i++ {
+			assert.NoError(t, q.Publish(context.TODO(), name, i))
+		}
+	}()
+
+	got := make([]int, 0, 10)
+	for msg := range msgs {
+		var i int
+		assert.NoError(t, msg.As(&i))
+
+		assert.NotContains(t, got, i) // no duplicates
+		got = append(got, i)
+
+		assert.NoError(t, msg.Ack())
+		if len(got) == 10 {
+			break
+		}
+	}
+}
+
+func TestInmemory__fifo(t *testing.T) {
+	q := NewInMemory(logger.NewTest(t))
+	name := names.IncompleteQueueName("testing")
+
+	msgs := make(chan Message)
+	go func() { // consumer 1
+		assert.NoError(t, q.Subscribe(context.TODO(), name, msgs))
+	}()
+	go func() { // producer
+		for i := 0; i < 10; i++ {
+			assert.NoError(t, q.Publish(context.TODO(), name, i))
+		}
+	}()
+
+	got := make([]int, 0, 10)
+	for msg := range msgs {
+		var i int
+		assert.NoError(t, msg.As(&i))
+
+		assert.Equal(t, len(got), i)
+
+		got = append(got, i)
+
+		assert.NoError(t, msg.Ack())
+		if len(got) == 10 {
+			break
+		}
+	}
+}

--- a/api/pkg/snapshots/worker/module.go
+++ b/api/pkg/snapshots/worker/module.go
@@ -15,7 +15,3 @@ func Module(c *di.Container) {
 	c.Import(service_users.Module)
 	c.Register(New)
 }
-
-func TestModule(c *di.Container) {
-	c.Register(NewSync)
-}


### PR DESCRIPTION
<p>api/queue: ensure inmemory implementation is exactly once fifo</p>

---

This PR was created by Nikita Galaiko (ngalaiko) on [Sturdy](https://getsturdy.com/sturdy-zyTDsnY/0bc1c202-e0a8-4f1c-9aa2-a9ff29db0cb7).

Update this PR by making changes through Sturdy.
